### PR TITLE
Add GitHub tracker support

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1245,9 +1245,10 @@ Important:
 
 - GitHub Issues only exposes `open` and `closed`. For GitHub tracker workflows, the Projects v2
   Status field, or the configured `project_status_field`, is the authoritative workflow state.
-- The normalized issue `identifier` SHOULD be the issue number prefixed with `#` or another stable
-  implementation-documented human-readable GitHub issue identifier. The normalized `url` SHOULD be
-  the issue's HTML URL.
+- The normalized issue `identifier` SHOULD be a stable, human-readable, route-safe single path
+  segment, such as `github-<owner>-<repo>-<number>`. It MUST NOT include `/`, `#`, or query/fragment
+  delimiters because observability API routes embed the identifier as one path segment. The
+  normalized `url` SHOULD be the issue's HTML URL.
 - Token permissions must cover both issue access and project access. Fine-grained tokens need
   repository Issues read/write plus project read/write access for the project owner. Classic
   personal access tokens need `read:project` for Projects v2 GraphQL queries and `project` for

--- a/SPEC.md
+++ b/SPEC.md
@@ -16,8 +16,8 @@ behavior.
 ## 1. Problem Statement
 
 Symphony is a long-running automation service that continuously reads work from an issue tracker
-(Linear in this specification version), creates an isolated workspace for each issue, and runs a
-coding agent session for that issue inside the workspace.
+(Linear or GitHub Issues + Projects v2 in this specification version), creates an isolated
+workspace for each issue, and runs a coding agent session for that issue inside the workspace.
 
 The service solves four operational problems:
 
@@ -129,7 +129,7 @@ Symphony is easiest to port when kept in these layers:
 4. `Execution Layer` (workspace + agent subprocess)
    - Filesystem lifecycle, workspace preparation, coding-agent protocol.
 
-5. `Integration Layer` (Linear adapter)
+5. `Integration Layer` (tracker adapters)
    - API calls and normalization for tracker data.
 
 6. `Observability Layer` (logs + OPTIONAL status surface)
@@ -137,7 +137,8 @@ Symphony is easiest to port when kept in these layers:
 
 ### 3.3 External Dependencies
 
-- Issue tracker API (Linear for `tracker.kind: linear` in this specification version).
+- Issue tracker API (Linear for `tracker.kind: linear`, or GitHub Issues + Projects v2 for
+  `tracker.kind: github`).
 - Local filesystem for workspaces and logs.
 - OPTIONAL workspace population tooling (for example Git CLI, if used).
 - Coding-agent executable that supports the targeted Codex app-server mode.
@@ -349,19 +350,55 @@ Fields:
 
 - `kind` (string)
   - REQUIRED for dispatch.
-  - Current supported value: `linear`
+  - Current supported values: `linear`, `github`
 - `endpoint` (string)
   - Default for `tracker.kind == "linear"`: `https://api.linear.app/graphql`
+  - Default for `tracker.kind == "github"`: `https://api.github.com`
 - `api_key` (string)
   - MAY be a literal token or `$VAR_NAME`.
   - Canonical environment variable for `tracker.kind == "linear"`: `LINEAR_API_KEY`.
+  - Canonical environment variable for `tracker.kind == "github"`: `GITHUB_TOKEN`.
   - If `$VAR_NAME` resolves to an empty string, treat the key as missing.
 - `project_slug` (string)
   - REQUIRED for dispatch when `tracker.kind == "linear"`.
+- `owner` (string)
+  - REQUIRED for dispatch when `tracker.kind == "github"`.
+  - GitHub repository owner or organization for the issue source repository.
+- `repo` (string)
+  - REQUIRED for dispatch when `tracker.kind == "github"`.
+  - GitHub repository name for the issue source repository.
+- `project_owner` (string)
+  - REQUIRED for dispatch when `tracker.kind == "github"`.
+  - GitHub user or organization that owns the Projects v2 project.
+- `project_owner_type` (string)
+  - REQUIRED for dispatch when `tracker.kind == "github"`.
+  - Supported values: `user`, `organization`.
+  - Default: `user`
+- `project_number` (integer)
+  - REQUIRED for dispatch when `tracker.kind == "github"`.
+  - The Projects v2 project number from the project URL.
+- `project_status_field` (string)
+  - REQUIRED for dispatch when `tracker.kind == "github"`.
+  - Default: `Status`
+  - The single-select Projects v2 field whose option name is treated as the normalized issue
+    `state`.
 - `active_states` (list of strings)
   - Default: `Todo`, `In Progress`
 - `terminal_states` (list of strings)
   - Default: `Closed`, `Cancelled`, `Canceled`, `Duplicate`, `Done`
+
+GitHub tracker notes:
+
+- GitHub Issues only exposes `open` and `closed`; the issue open/closed state is not expressive
+  enough for Symphony workflow dispatch. For `tracker.kind == "github"`, Projects v2
+  `project_status_field` is the workflow state source used for `active_states`,
+  `terminal_states`, prompt rendering, and reconciliation.
+- Candidate issues come from issues in `owner/repo` that are present in the configured Projects v2
+  project and whose `project_status_field` option is in `active_states`.
+- The GitHub token MUST be able to read and update repository issues and read and update the
+  configured Projects v2 project. For fine-grained tokens, grant repository Issues read/write and
+  project read/write access for the project owner. For classic personal access tokens, Projects v2
+  GraphQL queries use `read:project`, and GraphQL mutations use `project`.
 
 #### 5.3.2 `polling` (object)
 
@@ -562,6 +599,9 @@ Validation checks:
 - `tracker.kind` is present and supported.
 - `tracker.api_key` is present after `$` resolution.
 - `tracker.project_slug` is present when REQUIRED by the selected tracker kind.
+- GitHub tracker fields (`owner`, `repo`, `project_owner`, `project_owner_type`,
+  `project_number`, `project_status_field`, `active_states`, and `terminal_states`) are present
+  when REQUIRED by the selected tracker kind.
 - `codex.command` is present and non-empty.
 
 ### 6.4 Core Config Fields Summary (Cheat Sheet)
@@ -570,10 +610,18 @@ This section is intentionally redundant so a coding agent can implement the conf
 Extension fields are documented in the extension section that defines them. Core conformance does
 not require recognizing or validating extension fields unless that extension is implemented.
 
-- `tracker.kind`: string, REQUIRED, currently `linear`
-- `tracker.endpoint`: string, default `https://api.linear.app/graphql` when `tracker.kind=linear`
-- `tracker.api_key`: string or `$VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`
+- `tracker.kind`: string, REQUIRED, currently `linear` or `github`
+- `tracker.endpoint`: string, default `https://api.linear.app/graphql` when `tracker.kind=linear`,
+  default `https://api.github.com` when `tracker.kind=github`
+- `tracker.api_key`: string or `$VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`,
+  canonical env `GITHUB_TOKEN` when `tracker.kind=github`
 - `tracker.project_slug`: string, REQUIRED when `tracker.kind=linear`
+- `tracker.owner`: string, REQUIRED when `tracker.kind=github`
+- `tracker.repo`: string, REQUIRED when `tracker.kind=github`
+- `tracker.project_owner`: string, REQUIRED when `tracker.kind=github`
+- `tracker.project_owner_type`: string, REQUIRED when `tracker.kind=github`, default `user`
+- `tracker.project_number`: integer, REQUIRED when `tracker.kind=github`
+- `tracker.project_status_field`: string, REQUIRED when `tracker.kind=github`, default `Status`
 - `tracker.active_states`: list of strings, default `["Todo", "In Progress"]`
 - `tracker.terminal_states`: list of strings, default `["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]`
 - `polling.interval_ms`: integer, default `30000`
@@ -1130,7 +1178,7 @@ Note:
 
 - Workspaces are intentionally preserved after successful runs.
 
-## 11. Issue Tracker Integration Contract (Linear-Compatible)
+## 11. Issue Tracker Integration Contract
 
 ### 11.1 REQUIRED Operations
 
@@ -1167,7 +1215,46 @@ Important:
 A non-Linear implementation MAY change transport details, but the normalized outputs MUST match the
 domain model in Section 4.
 
-### 11.3 Normalization Rules
+### 11.3 Query Semantics (GitHub Issues + Projects v2)
+
+GitHub-specific requirements for `tracker.kind == "github"`:
+
+- `tracker.kind == "github"`
+- REST endpoint default `https://api.github.com`; GraphQL endpoint is derived from it as the
+  corresponding GitHub GraphQL API endpoint.
+- Auth token sent in the `Authorization` header.
+- `tracker.owner` and `tracker.repo` identify the issue source repository.
+- `tracker.project_owner`, `tracker.project_owner_type`, and `tracker.project_number` identify the
+  Projects v2 project to query.
+- `tracker.project_owner_type == "user"` resolves the project through the GraphQL `user` owner.
+- `tracker.project_owner_type == "organization"` resolves the project through the GraphQL
+  `organization` owner.
+- `tracker.project_status_field` names the Projects v2 single-select field used as the normalized
+  issue `state`.
+- Candidate issue query filters to project items whose content is an issue in `owner/repo` and whose
+  `project_status_field` option is in `tracker.active_states`.
+- Issue-state refresh by ID returns the current Projects v2 `project_status_field` option for each
+  configured project item.
+- Terminal cleanup fetches project issues whose `project_status_field` option is in
+  `tracker.terminal_states`.
+- Pagination REQUIRED for project items and issue lists.
+- Page size default: `50`
+- Network timeout: `30000 ms`
+
+Important:
+
+- GitHub Issues only exposes `open` and `closed`. For GitHub tracker workflows, the Projects v2
+  Status field, or the configured `project_status_field`, is the authoritative workflow state.
+- The normalized issue `identifier` SHOULD be the issue number prefixed with `#` or another stable
+  implementation-documented human-readable GitHub issue identifier. The normalized `url` SHOULD be
+  the issue's HTML URL.
+- Token permissions must cover both issue access and project access. Fine-grained tokens need
+  repository Issues read/write plus project read/write access for the project owner. Classic
+  personal access tokens need `read:project` for Projects v2 GraphQL queries and `project` for
+  Projects v2 GraphQL mutations; workflows that edit issues also need issue read/write authority
+  for the repository.
+
+### 11.4 Normalization Rules
 
 Candidate issue normalization SHOULD produce fields listed in Section 4.1.1.
 
@@ -1178,7 +1265,7 @@ Additional normalization details:
 - `priority` -> integer only (non-integers become null)
 - `created_at` and `updated_at` -> parse ISO-8601 timestamps
 
-### 11.4 Error Handling Contract
+### 11.5 Error Handling Contract
 
 RECOMMENDED error categories:
 
@@ -1190,6 +1277,12 @@ RECOMMENDED error categories:
 - `linear_graphql_errors`
 - `linear_unknown_payload`
 - `linear_missing_end_cursor` (pagination integrity error)
+- `github_api_request` (transport failures)
+- `github_api_status` (non-2xx HTTP)
+- `github_graphql_errors`
+- `github_unknown_payload`
+- `github_missing_project_status_field`
+- `github_missing_end_cursor` (pagination integrity error)
 
 Orchestrator behavior on tracker errors:
 
@@ -1197,7 +1290,7 @@ Orchestrator behavior on tracker errors:
 - Running-state refresh failure: log and keep active workers running.
 - Startup terminal cleanup failure: log warning and continue startup.
 
-### 11.5 Tracker Writes (Important Boundary)
+### 11.6 Tracker Writes (Important Boundary)
 
 Symphony does not require first-class tracker write APIs in the orchestrator.
 
@@ -1521,7 +1614,7 @@ API design notes:
 1. `Workflow/Config Failures`
    - Missing `WORKFLOW.md`
    - Invalid YAML front matter
-   - Unsupported tracker kind or missing tracker credentials/project slug
+   - Unsupported tracker kind or missing tracker credentials/project identity
    - Missing coding-agent executable
 
 2. `Workspace Failures`
@@ -1663,10 +1756,11 @@ Possible hardening measures include:
   of running with a maximally permissive configuration.
 - Adding external isolation layers such as OS/container/VM sandboxing, network restrictions, or
   separate credentials beyond the built-in Codex policy controls.
-- Filtering which Linear issues, projects, teams, labels, or other tracker sources are eligible for
-  dispatch so untrusted or out-of-scope tasks do not automatically reach the agent.
-- Narrowing the `linear_graphql` tool so it can only read or mutate data inside the
-  intended project scope, rather than exposing general workspace-wide tracker access.
+- Filtering which Linear or GitHub issues, projects, teams, labels, or other tracker sources are
+  eligible for dispatch so untrusted or out-of-scope tasks do not automatically reach the agent.
+- Narrowing tracker-specific agent tools, such as `linear_graphql`, so they can only read or mutate
+  data inside the intended project scope, rather than exposing general workspace-wide tracker
+  access.
 - Reducing the set of client-side tools, credentials, filesystem paths, and network destinations
   available to the agent to the minimum needed for the workflow.
 
@@ -1940,8 +2034,10 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Invalid YAML front matter returns typed error
 - Front matter non-map returns typed error
 - Config defaults apply when OPTIONAL values are missing
-- `tracker.kind` validation enforces currently supported kind (`linear`)
+- `tracker.kind` validation enforces currently supported kinds (`linear`, `github`)
 - `tracker.api_key` works (including `$VAR` indirection)
+- GitHub tracker validation enforces `owner`, `repo`, `project_owner`, `project_owner_type`,
+  `project_number`, `project_status_field`, `active_states`, and `terminal_states`
 - `$VAR` resolution works for tracker API key and path values
 - `~` path expansion works
 - `codex.command` is preserved as a shell command string
@@ -1966,8 +2062,10 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 
 ### 17.3 Issue Tracker Client
 
-- Candidate issue fetch uses active states and project slug
+- Candidate issue fetch uses active states and the selected tracker's project identity
 - Linear query uses the specified project filter field (`slugId`)
+- GitHub query uses the configured Projects v2 `project_status_field` as the normalized issue state
+- GitHub issue `open`/`closed` state is not used as the workflow state source
 - Empty `fetch_issues_by_states([])` returns empty without API call
 - Pagination preserves order across multiple pages
 - Blockers are normalized from inverse relations of type `blocks`
@@ -2092,12 +2190,13 @@ Use the same validation profiles as Section 17:
   exposes the baseline endpoints/error semantics in Section 13.7 if shipped.
 - `linear_graphql` client-side tool extension exposes raw Linear GraphQL access through the
   app-server session using configured Symphony auth.
+- GitHub tracker adapter supports GitHub Issues + Projects v2 Status-based workflow state.
 - TODO: Persist retry queue and session metadata across process restarts.
 - TODO: Make observability settings configurable in workflow front matter without prescribing UI
   implementation details.
 - TODO: Add first-class tracker write APIs (comments/state transitions) in the orchestrator instead
   of only via agent tools.
-- TODO: Add pluggable issue tracker adapters beyond Linear.
+- TODO: Add pluggable issue tracker adapters beyond Linear and GitHub.
 
 ### 18.3 Operational Validation Before Production (RECOMMENDED)
 

--- a/elixir/AGENTS.md
+++ b/elixir/AGENTS.md
@@ -48,6 +48,7 @@ mix specs.check
 
 ## PR Requirements
 
+- PR titles must describe the change directly; do not prefix them with `[codex]`.
 - PR body must follow `../.github/pull_request_template.md` exactly.
 - Validate PR body locally when needed:
 

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -159,6 +159,8 @@ Notes:
 - GitHub Issues only has `open` and `closed`; the configured Projects v2 `project_status_field`
   value is the workflow state that Symphony compares against `active_states` and
   `terminal_states`.
+- GitHub issue identifiers are emitted as route-safe single path segments such as
+  `github-your-org-your-repo-123`; `issue.id` remains the raw GitHub issue number for API updates.
 - `project_status_field` should name a Projects v2 single-select field, usually `Status`.
   Use `project_owner_type: user` for user-owned projects and `organization` for org-owned
   projects.

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -13,32 +13,39 @@ This directory contains the current Elixir/OTP implementation of Symphony, based
 
 ## How it works
 
-1. Polls Linear for candidate work
+1. Polls the configured tracker for candidate work
 2. Creates a workspace per issue
 3. Launches Codex in [App Server mode](https://developers.openai.com/codex/app-server/) inside the
    workspace
 4. Sends a workflow prompt to Codex
 5. Keeps Codex working on the issue until the work is done
 
-During app-server sessions, Symphony also serves a client-side `linear_graphql` tool so that repo
-skills can make raw Linear GraphQL calls.
+During Linear app-server sessions, Symphony also serves a client-side `linear_graphql` tool so that
+repo skills can make raw Linear GraphQL calls.
 
-If a claimed issue moves to a terminal state (`Done`, `Closed`, `Cancelled`, or `Duplicate`),
-Symphony stops the active agent for that issue and cleans up matching workspaces.
+If a claimed issue moves to a configured terminal state (`Done`, `Closed`, `Cancelled`, or
+`Duplicate` by default), Symphony stops the active agent for that issue and cleans up matching
+workspaces.
 
 ## How to use it
 
 1. Make sure your codebase is set up to work well with agents: see
    [Harness engineering](https://openai.com/index/harness-engineering/).
-2. Get a new personal token in Linear via Settings → Security & access → Personal API keys, and
-   set it as the `LINEAR_API_KEY` environment variable.
+2. Configure tracker credentials:
+   - For Linear, get a personal token via Settings → Security & access → Personal API keys, and set
+     it as the `LINEAR_API_KEY` environment variable.
+   - For GitHub, set `GITHUB_TOKEN` to a token that can read/write repository issues and read/write
+     the configured Projects v2 project.
 3. Copy this directory's `WORKFLOW.md` to your repo.
 4. Optionally copy the `commit`, `push`, `pull`, `land`, and `linear` skills to your repo.
    - The `linear` skill expects Symphony's `linear_graphql` app-server tool for raw Linear GraphQL
      operations such as comment editing or upload flows.
 5. Customize the copied `WORKFLOW.md` file for your project.
    - To get your project's slug, right-click the project and copy its URL. The slug is part of the
-     URL.
+     URL. This applies to `tracker.kind: linear`.
+   - For GitHub, use `tracker.kind: github` and configure the repository plus the Projects v2
+     project owner, project number, and status field. GitHub Issues alone only has `open` and
+     `closed`; Symphony uses the configured Projects v2 Status field as the workflow state source.
    - When creating a workflow based on this repo, note that it depends on non-standard Linear
      issue statuses: "Rework", "Human Review", and "Merging". You can customize them in
      Team Settings → Workflow in Linear.
@@ -83,7 +90,7 @@ Optional flags:
 The `WORKFLOW.md` file uses YAML front matter for configuration, plus a Markdown body used as the
 Codex session prompt.
 
-Minimal example:
+Minimal Linear example:
 
 ```md
 ---
@@ -107,9 +114,58 @@ You are working on a Linear issue {{ issue.identifier }}.
 Title: {{ issue.title }} Body: {{ issue.description }}
 ```
 
+Minimal GitHub Issues + Projects v2 example:
+
+```md
+---
+tracker:
+  kind: github
+  owner: your-org
+  repo: your-repo
+  project_owner: your-org
+  project_owner_type: organization
+  project_number: 12
+  project_status_field: Status
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+    - Closed
+  api_key: $GITHUB_TOKEN
+workspace:
+  root: ~/code/workspaces
+hooks:
+  after_create: |
+    git clone git@github.com:your-org/your-repo.git .
+agent:
+  max_concurrent_agents: 10
+  max_turns: 20
+codex:
+  command: codex app-server
+---
+
+You are working on GitHub issue {{ issue.identifier }}.
+
+Title: {{ issue.title }} Body: {{ issue.description }}
+```
+
 Notes:
 
 - If a value is missing, defaults are used.
+- For `tracker.kind: github`, configure `owner`, `repo`, `project_owner`,
+  `project_owner_type`, `project_number`, `project_status_field`, `active_states`,
+  `terminal_states`, and an API token through `api_key` or `GITHUB_TOKEN`.
+- GitHub Issues only has `open` and `closed`; the configured Projects v2 `project_status_field`
+  value is the workflow state that Symphony compares against `active_states` and
+  `terminal_states`.
+- `project_status_field` should name a Projects v2 single-select field, usually `Status`.
+  Use `project_owner_type: user` for user-owned projects and `organization` for org-owned
+  projects.
+- GitHub tokens need Issues read/write on the repository and Projects v2 read/write access on the
+  project owner. Classic personal access tokens use `read:project` for Projects v2 GraphQL queries
+  and `project` for Projects v2 GraphQL mutations; fine-grained tokens should grant repository
+  Issues read/write and project read/write access.
 - Safer Codex defaults are used when policy fields are omitted:
   - `codex.approval_policy` defaults to `{"reject":{"sandbox_approval":true,"rules":true,"mcp_elicitations":true}}`
   - `codex.thread_sandbox` defaults to `workspace-write`
@@ -127,7 +183,8 @@ Notes:
   `git clone ... .` there, along with any other setup commands you need.
 - If a hook needs `mise exec` inside a freshly cloned workspace, trust the repo config and fetch
   the project dependencies in `hooks.after_create` before invoking `mise` later from other hooks.
-- `tracker.api_key` reads from `LINEAR_API_KEY` when unset or when value is `$LINEAR_API_KEY`.
+- `tracker.api_key` reads from `LINEAR_API_KEY` for Linear or `GITHUB_TOKEN` for GitHub when unset
+  or when value is the matching `$VAR`.
 - For path values, `~` is expanded to the home directory.
 - For env-backed path values, use `$VAR`. `workspace.root` resolves `$VAR` before path handling,
   while `codex.command` stays a shell command string and any `$VAR` expansion there happens in the

--- a/elixir/lib/mix/tasks/pr_body.check.ex
+++ b/elixir/lib/mix/tasks/pr_body.check.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.PrBody.Check do
 
   defp read_template_candidate(path) do
     case File.read(path) do
-      {:ok, content} -> {:ok, path, content}
+      {:ok, content} -> {:ok, path, normalize_line_endings(content)}
       {:error, _reason} -> nil
     end
   end
@@ -69,9 +69,13 @@ defmodule Mix.Tasks.PrBody.Check do
 
   defp read_file(path) do
     case File.read(path) do
-      {:ok, content} -> {:ok, content}
+      {:ok, content} -> {:ok, normalize_line_endings(content)}
       {:error, reason} -> {:error, "Unable to read #{path}: #{inspect(reason)}"}
     end
+  end
+
+  defp normalize_line_endings(content) when is_binary(content) do
+    String.replace(content, "\r\n", "\n")
   end
 
   defp extract_template_headings(template, template_path) do

--- a/elixir/lib/mix/tasks/workspace.before_remove.ex
+++ b/elixir/lib/mix/tasks/workspace.before_remove.ex
@@ -106,7 +106,7 @@ defmodule Mix.Tasks.Workspace.BeforeRemove do
   end
 
   defp closing_comment(branch) do
-    "Closing because the Linear issue for branch #{branch} entered a terminal state without merge."
+    "Closing because the tracker issue for branch #{branch} entered a terminal state without merge."
   end
 
   defp format_output(""), do: ""

--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -1,11 +1,12 @@
 defmodule SymphonyElixir.AgentRunner do
   @moduledoc """
-  Executes a single Linear issue in its workspace with Codex.
+  Executes a single tracker issue in its workspace with Codex.
   """
 
   require Logger
   alias SymphonyElixir.Codex.AppServer
-  alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Workspace}
+  alias SymphonyElixir.{Config, PromptBuilder, Tracker, Workspace}
+  alias SymphonyElixir.Tracker.Issue
 
   @type worker_host :: String.t() | nil
 
@@ -136,7 +137,7 @@ defmodule SymphonyElixir.AgentRunner do
     """
     Continuation guidance:
 
-    - The previous Codex turn completed normally, but the Linear issue is still in an active state.
+    - The previous Codex turn completed normally, but the tracker issue is still in an active state.
     - This is continuation turn ##{turn_number} of #{max_turns} for the current agent run.
     - Resume from the current workspace and workpad state instead of restarting from scratch.
     - The original task instructions and prior turn context are already present in this thread, so do not restate them before acting.

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -85,7 +85,7 @@ defmodule SymphonyElixir.Codex.AppServer do
 
     tool_executor =
       Keyword.get(opts, :tool_executor, fn tool, arguments ->
-        DynamicTool.execute(tool, arguments)
+        DynamicTool.execute(tool, arguments, workspace: workspace)
       end)
 
     case start_turn(port, thread_id, prompt, issue, workspace, approval_policy, turn_sandbox_policy) do

--- a/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
+++ b/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
@@ -416,9 +416,7 @@ defmodule SymphonyElixir.Codex.DynamicTool do
             {:ok, :linear}
 
           has_issue_number? and has_issue_id? ->
-            {:error,
-             {:sync_workpad,
-              "cannot infer tracker when both `issue_number` and `issue_id` are provided; set `tracker` to `github` or `linear`."}}
+            {:error, {:sync_workpad, "cannot infer tracker when both `issue_number` and `issue_id` are provided; set `tracker` to `github` or `linear`."}}
 
           true ->
             {:error, {:sync_workpad, "`issue_number` is required for GitHub sync or `issue_id` is required for Linear sync."}}

--- a/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
+++ b/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
@@ -3,7 +3,9 @@ defmodule SymphonyElixir.Codex.DynamicTool do
   Executes client-side tool calls requested by Codex app-server turns.
   """
 
-  alias SymphonyElixir.Linear.Client
+  alias SymphonyElixir.GitHub.Client, as: GitHubClient
+  alias SymphonyElixir.Linear.Client, as: LinearClient
+  alias SymphonyElixir.{Config, PathSafety}
 
   @linear_graphql_tool "linear_graphql"
   @linear_graphql_description """
@@ -26,11 +28,145 @@ defmodule SymphonyElixir.Codex.DynamicTool do
     }
   }
 
+  @github_graphql_tool "github_graphql"
+  @github_graphql_description """
+  Execute a raw GraphQL query or mutation against GitHub using Symphony's configured auth.
+  """
+  @github_graphql_input_schema %{
+    "type" => "object",
+    "additionalProperties" => false,
+    "required" => ["query"],
+    "properties" => %{
+      "query" => %{
+        "type" => "string",
+        "description" => "GraphQL query or mutation document to execute against GitHub."
+      },
+      "variables" => %{
+        "type" => ["object", "null"],
+        "description" => "Optional GraphQL variables object.",
+        "additionalProperties" => true
+      }
+    }
+  }
+
+  @sync_workpad_tool "sync_workpad"
+  @sync_workpad_description """
+  Create or update a persistent tracker workpad comment from a local markdown file.
+  """
+  @sync_workpad_input_schema %{
+    "type" => "object",
+    "additionalProperties" => false,
+    "required" => ["file_path"],
+    "properties" => %{
+      "tracker" => %{
+        "type" => "string",
+        "enum" => ["github", "linear"],
+        "description" => "Tracker to sync. Omit to infer from `issue_number` for GitHub or `issue_id` for Linear."
+      },
+      "file_path" => %{
+        "type" => "string",
+        "description" =>
+          "Path to the local markdown file whose contents become the comment body. " <>
+            "Relative paths are allowed only when Symphony provides an active workspace."
+      },
+      "issue_number" => %{
+        "type" => ["integer", "string"],
+        "description" => "GitHub issue number. Required for GitHub workpad sync."
+      },
+      "issue_id" => %{
+        "type" => "string",
+        "description" => "Linear issue identifier or internal UUID. Required for Linear workpad sync."
+      },
+      "owner" => %{
+        "type" => "string",
+        "description" => "GitHub repository owner. Defaults to tracker.owner from WORKFLOW.md when omitted."
+      },
+      "repo" => %{
+        "type" => "string",
+        "description" => "GitHub repository name. Defaults to tracker.repo from WORKFLOW.md when omitted."
+      },
+      "comment_id" => %{
+        "type" => "string",
+        "description" =>
+          "Existing tracker comment ID to update. For GitHub, pass the issue comment node ID. " <>
+            "Omit to create a new workpad comment."
+      }
+    }
+  }
+
+  @sync_workpad_allowed_keys ~w(tracker file_path issue_number issue_id owner repo comment_id)
+
+  @linear_sync_workpad_create """
+  mutation SymphonyLinearCreateWorkpad($issueId: String!, $body: String!) {
+    commentCreate(input: {issueId: $issueId, body: $body}) {
+      success
+      comment {
+        id
+        url
+      }
+    }
+  }
+  """
+
+  @linear_sync_workpad_update """
+  mutation SymphonyLinearUpdateWorkpad($id: String!, $body: String!) {
+    commentUpdate(id: $id, input: {body: $body}) {
+      success
+      comment {
+        id
+        url
+      }
+    }
+  }
+  """
+
+  @github_issue_node_query """
+  query SymphonyGitHubIssueNode($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        id
+        number
+        url
+      }
+    }
+  }
+  """
+
+  @github_sync_workpad_create """
+  mutation SymphonyGitHubCreateWorkpad($subjectId: ID!, $body: String!) {
+    addComment(input: {subjectId: $subjectId, body: $body}) {
+      commentEdge {
+        node {
+          id
+          url
+        }
+      }
+    }
+  }
+  """
+
+  @github_sync_workpad_update """
+  mutation SymphonyGitHubUpdateWorkpad($id: ID!, $body: String!) {
+    updateIssueComment(input: {id: $id, body: $body}) {
+      issueComment {
+        id
+        url
+      }
+    }
+  }
+  """
+
   @spec execute(String.t() | nil, term(), keyword()) :: map()
   def execute(tool, arguments, opts \\ []) do
     case tool do
       @linear_graphql_tool ->
         execute_linear_graphql(arguments, opts)
+
+      @github_graphql_tool ->
+        execute_github_graphql(arguments, opts)
+
+      @sync_workpad_tool ->
+        execute_sync_workpad(arguments, opts)
 
       other ->
         failure_response(%{
@@ -49,30 +185,151 @@ defmodule SymphonyElixir.Codex.DynamicTool do
         "name" => @linear_graphql_tool,
         "description" => @linear_graphql_description,
         "inputSchema" => @linear_graphql_input_schema
+      },
+      %{
+        "name" => @github_graphql_tool,
+        "description" => @github_graphql_description,
+        "inputSchema" => @github_graphql_input_schema
+      },
+      %{
+        "name" => @sync_workpad_tool,
+        "description" => @sync_workpad_description,
+        "inputSchema" => @sync_workpad_input_schema
       }
     ]
   end
 
   defp execute_linear_graphql(arguments, opts) do
-    linear_client = Keyword.get(opts, :linear_client, &Client.graphql/3)
+    execute_graphql(arguments, Keyword.get(opts, :linear_client, &LinearClient.graphql/3), @linear_graphql_tool)
+  end
 
-    with {:ok, query, variables} <- normalize_linear_graphql_arguments(arguments),
-         {:ok, response} <- linear_client.(query, variables, []) do
+  defp execute_github_graphql(arguments, opts) do
+    execute_graphql(arguments, Keyword.get(opts, :github_client, &GitHubClient.graphql/3), @github_graphql_tool)
+  end
+
+  defp execute_graphql(arguments, client, tool_name) do
+    with {:ok, query, variables} <- normalize_graphql_arguments(arguments),
+         {:ok, response} <- client.(query, variables, []) do
       graphql_response(response)
     else
+      {:error, {:graphql_arguments, reason}} ->
+        failure_response(graphql_argument_error_payload(tool_name, reason))
+
       {:error, reason} ->
-        failure_response(tool_error_payload(reason))
+        failure_response(graphql_transport_error_payload(tool_name, reason))
     end
   end
 
-  defp normalize_linear_graphql_arguments(arguments) when is_binary(arguments) do
+  defp execute_sync_workpad(arguments, opts) do
+    with {:ok, sync_args} <- normalize_sync_workpad_arguments(arguments),
+         {:ok, body} <- read_workpad_file(sync_args.file_path, opts) do
+      case sync_args.tracker do
+        :github -> sync_github_workpad(sync_args, body, opts)
+        :linear -> sync_linear_workpad(sync_args, body, opts)
+      end
+    else
+      {:error, reason} ->
+        failure_response(sync_workpad_error_payload(reason))
+    end
+  end
+
+  defp sync_linear_workpad(sync_args, body, opts) do
+    {query, variables} =
+      case sync_args.comment_id do
+        nil ->
+          {@linear_sync_workpad_create, %{"issueId" => sync_args.issue_id, "body" => body}}
+
+        comment_id ->
+          {@linear_sync_workpad_update, %{"id" => comment_id, "body" => body}}
+      end
+
+    execute_linear_graphql(%{"query" => query, "variables" => variables}, opts)
+  end
+
+  defp sync_github_workpad(sync_args, body, opts) do
+    github_client = Keyword.get(opts, :github_client, &GitHubClient.graphql/3)
+
+    case sync_args.comment_id do
+      nil ->
+        sync_new_github_workpad(sync_args, body, opts, github_client)
+
+      comment_id ->
+        execute_graphql(
+          %{
+            "query" => @github_sync_workpad_update,
+            "variables" => %{"id" => comment_id, "body" => body}
+          },
+          github_client,
+          @github_graphql_tool
+        )
+    end
+  end
+
+  defp sync_new_github_workpad(sync_args, body, _opts, github_client) do
+    with {:ok, owner, repo} <- resolve_github_repo(sync_args),
+         {:ok, issue_node_id} <- fetch_github_issue_node_id(github_client, owner, repo, sync_args.issue_number) do
+      execute_graphql(
+        %{
+          "query" => @github_sync_workpad_create,
+          "variables" => %{"subjectId" => issue_node_id, "body" => body}
+        },
+        github_client,
+        @github_graphql_tool
+      )
+    else
+      {:error, {:github_issue_lookup_response, response}} ->
+        graphql_response(response)
+
+      {:error, {:github_issue_lookup_client, reason}} ->
+        failure_response(graphql_transport_error_payload(@github_graphql_tool, reason))
+
+      {:error, reason} ->
+        failure_response(sync_workpad_error_payload(reason))
+    end
+  end
+
+  defp fetch_github_issue_node_id(github_client, owner, repo, issue_number) do
+    variables = %{"owner" => owner, "repo" => repo, "number" => issue_number}
+
+    case github_client.(@github_issue_node_query, variables, []) do
+      {:ok, response} ->
+        cond do
+          not graphql_success?(response) ->
+            {:error, {:github_issue_lookup_response, response}}
+
+          match?({:ok, _}, github_issue_node_id(response)) ->
+            github_issue_node_id(response)
+
+          true ->
+            {:error, {:sync_workpad, "GitHub issue ##{issue_number} was not found in #{owner}/#{repo}."}}
+        end
+
+      {:error, reason} ->
+        {:error, {:github_issue_lookup_client, reason}}
+    end
+  end
+
+  defp github_issue_node_id(response) do
+    case get_in(response, ["data", "repository", "issue", "id"]) do
+      issue_node_id when is_binary(issue_node_id) ->
+        case String.trim(issue_node_id) do
+          "" -> :error
+          trimmed -> {:ok, trimmed}
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp normalize_graphql_arguments(arguments) when is_binary(arguments) do
     case String.trim(arguments) do
-      "" -> {:error, :missing_query}
+      "" -> {:error, {:graphql_arguments, :missing_query}}
       query -> {:ok, query, %{}}
     end
   end
 
-  defp normalize_linear_graphql_arguments(arguments) when is_map(arguments) do
+  defp normalize_graphql_arguments(arguments) when is_map(arguments) do
     case normalize_query(arguments) do
       {:ok, query} ->
         case normalize_variables(arguments) do
@@ -80,15 +337,15 @@ defmodule SymphonyElixir.Codex.DynamicTool do
             {:ok, query, variables}
 
           {:error, reason} ->
-            {:error, reason}
+            {:error, {:graphql_arguments, reason}}
         end
 
       {:error, reason} ->
-        {:error, reason}
+        {:error, {:graphql_arguments, reason}}
     end
   end
 
-  defp normalize_linear_graphql_arguments(_arguments), do: {:error, :invalid_arguments}
+  defp normalize_graphql_arguments(_arguments), do: {:error, {:graphql_arguments, :invalid_arguments}}
 
   defp normalize_query(arguments) do
     case Map.get(arguments, "query") || Map.get(arguments, :query) do
@@ -110,15 +367,314 @@ defmodule SymphonyElixir.Codex.DynamicTool do
     end
   end
 
-  defp graphql_response(response) do
-    success =
-      case response do
-        %{"errors" => errors} when is_list(errors) and errors != [] -> false
-        %{errors: errors} when is_list(errors) and errors != [] -> false
-        _ -> true
+  defp normalize_sync_workpad_arguments(arguments) when is_map(arguments) do
+    with :ok <- validate_sync_workpad_keys(arguments),
+         {:ok, file_path} <- required_sync_string(arguments, "file_path"),
+         {:ok, tracker} <- infer_sync_workpad_tracker(arguments),
+         {:ok, comment_id} <- optional_sync_string(arguments, "comment_id") do
+      case tracker do
+        :github -> normalize_github_sync_workpad(arguments, file_path, comment_id)
+        :linear -> normalize_linear_sync_workpad(arguments, file_path, comment_id)
       end
+    end
+  end
 
-    dynamic_tool_response(success, encode_payload(response))
+  defp normalize_sync_workpad_arguments(_arguments) do
+    {:error, {:sync_workpad, "`sync_workpad` expects an object argument."}}
+  end
+
+  defp validate_sync_workpad_keys(arguments) do
+    unknown_keys =
+      arguments
+      |> Map.keys()
+      |> Enum.map(&sync_key_name/1)
+      |> Enum.reject(&(&1 in @sync_workpad_allowed_keys))
+      |> Enum.sort()
+
+    case unknown_keys do
+      [] ->
+        :ok
+
+      keys ->
+        formatted_keys = keys |> Enum.map(&"`#{&1}`") |> Enum.join(", ")
+        {:error, {:sync_workpad, "unsupported argument(s): #{formatted_keys}."}}
+    end
+  end
+
+  defp infer_sync_workpad_tracker(arguments) do
+    tracker = sync_field(arguments, "tracker")
+    has_issue_number? = sync_field_present?(arguments, "issue_number")
+    has_issue_id? = sync_field_present?(arguments, "issue_id")
+
+    case tracker do
+      nil ->
+        cond do
+          has_issue_number? and not has_issue_id? ->
+            {:ok, :github}
+
+          has_issue_id? and not has_issue_number? ->
+            {:ok, :linear}
+
+          has_issue_number? and has_issue_id? ->
+            {:error,
+             {:sync_workpad,
+              "cannot infer tracker when both `issue_number` and `issue_id` are provided; set `tracker` to `github` or `linear`."}}
+
+          true ->
+            {:error, {:sync_workpad, "`issue_number` is required for GitHub sync or `issue_id` is required for Linear sync."}}
+        end
+
+      tracker when is_binary(tracker) ->
+        case tracker |> String.trim() |> String.downcase() do
+          "github" -> {:ok, :github}
+          "linear" -> {:ok, :linear}
+          _ -> {:error, {:sync_workpad, "`tracker` must be either `github` or `linear`."}}
+        end
+
+      _ ->
+        {:error, {:sync_workpad, "`tracker` must be either `github` or `linear`."}}
+    end
+  end
+
+  defp normalize_github_sync_workpad(arguments, file_path, comment_id) do
+    with :ok <- reject_sync_field(arguments, "issue_id", "`issue_id` is only valid for Linear workpad sync."),
+         {:ok, issue_number} <- required_issue_number(arguments),
+         {:ok, owner} <- optional_sync_string(arguments, "owner"),
+         {:ok, repo} <- optional_sync_string(arguments, "repo") do
+      {:ok,
+       %{
+         tracker: :github,
+         file_path: file_path,
+         issue_number: issue_number,
+         owner: owner,
+         repo: repo,
+         comment_id: comment_id
+       }}
+    end
+  end
+
+  defp normalize_linear_sync_workpad(arguments, file_path, comment_id) do
+    with :ok <- reject_sync_field(arguments, "issue_number", "`issue_number` is only valid for GitHub workpad sync."),
+         :ok <- reject_sync_field(arguments, "owner", "`owner` is only valid for GitHub workpad sync."),
+         :ok <- reject_sync_field(arguments, "repo", "`repo` is only valid for GitHub workpad sync."),
+         {:ok, issue_id} <- required_sync_string(arguments, "issue_id") do
+      {:ok,
+       %{
+         tracker: :linear,
+         file_path: file_path,
+         issue_id: issue_id,
+         comment_id: comment_id
+       }}
+    end
+  end
+
+  defp reject_sync_field(arguments, field, message) do
+    if sync_field_present?(arguments, field) do
+      {:error, {:sync_workpad, message}}
+    else
+      :ok
+    end
+  end
+
+  defp required_sync_string(arguments, field) do
+    case sync_field(arguments, field) do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> {:error, {:sync_workpad, "`#{field}` is required."}}
+          trimmed -> {:ok, trimmed}
+        end
+
+      _ ->
+        {:error, {:sync_workpad, "`#{field}` is required."}}
+    end
+  end
+
+  defp optional_sync_string(arguments, field) do
+    case sync_field(arguments, field) do
+      nil ->
+        {:ok, nil}
+
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> {:ok, nil}
+          trimmed -> {:ok, trimmed}
+        end
+
+      _ ->
+        {:error, {:sync_workpad, "`#{field}` must be a string when provided."}}
+    end
+  end
+
+  defp required_issue_number(arguments) do
+    case sync_field(arguments, "issue_number") do
+      value when is_integer(value) and value > 0 ->
+        {:ok, value}
+
+      value when is_binary(value) ->
+        case Integer.parse(String.trim(value)) do
+          {number, ""} when number > 0 -> {:ok, number}
+          _ -> {:error, {:sync_workpad, "`issue_number` must be a positive integer."}}
+        end
+
+      _ ->
+        {:error, {:sync_workpad, "`issue_number` must be a positive integer."}}
+    end
+  end
+
+  defp sync_field(arguments, field) do
+    Map.get(arguments, field) || Map.get(arguments, String.to_atom(field))
+  end
+
+  defp sync_field_present?(arguments, field) do
+    case sync_field(arguments, field) do
+      nil -> false
+      value when is_binary(value) -> String.trim(value) != ""
+      _ -> true
+    end
+  end
+
+  defp sync_key_name(key) when is_atom(key), do: Atom.to_string(key)
+  defp sync_key_name(key), do: to_string(key)
+
+  defp read_workpad_file(file_path, opts) do
+    with {:ok, read_path} <- resolve_workpad_read_path(file_path, opts),
+         {:ok, body} <- File.read(read_path) do
+      case body do
+        "" -> {:error, {:sync_workpad, "file is empty: `#{file_path}`."}}
+        body -> {:ok, body}
+      end
+    else
+      {:error, {:sync_workpad, _message} = reason} ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, {:sync_workpad, "cannot read `#{file_path}`: #{:file.format_error(reason)}."}}
+    end
+  end
+
+  defp resolve_workpad_read_path(file_path, opts) do
+    cond do
+      String.contains?(file_path, [<<0>>, "\n", "\r"]) ->
+        {:error, {:sync_workpad, "`file_path` must not contain control characters."}}
+
+      workspace = valid_workspace_opt(opts) ->
+        resolve_workpad_read_path_in_workspace(file_path, workspace)
+
+      Keyword.has_key?(opts, :workspace) ->
+        {:error, {:sync_workpad, "`workspace` option must be a non-empty string when provided."}}
+
+      Path.type(file_path) == :absolute ->
+        canonicalize_workpad_path(file_path)
+
+      true ->
+        {:error, {:sync_workpad, "`file_path` must be absolute when no active workspace is configured."}}
+    end
+  end
+
+  defp canonicalize_workpad_path(path) do
+    case PathSafety.canonicalize(path) do
+      {:ok, canonical_path} ->
+        {:ok, canonical_path}
+
+      {:error, {:path_canonicalize_failed, failed_path, reason}} ->
+        {:error, {:sync_workpad, "cannot resolve `#{failed_path}`: #{inspect(reason)}."}}
+    end
+  end
+
+  defp valid_workspace_opt(opts) do
+    case Keyword.get(opts, :workspace) do
+      workspace when is_binary(workspace) ->
+        case String.trim(workspace) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp resolve_workpad_read_path_in_workspace(file_path, workspace) do
+    expanded_workspace = Path.expand(workspace)
+    expanded_path = Path.expand(file_path, expanded_workspace)
+
+    with {:ok, canonical_workspace} <- PathSafety.canonicalize(expanded_workspace),
+         {:ok, canonical_path} <- PathSafety.canonicalize(expanded_path) do
+      if path_within?(canonical_path, canonical_workspace) do
+        {:ok, canonical_path}
+      else
+        {:error, {:sync_workpad, "`file_path` must stay within the active workspace."}}
+      end
+    else
+      {:error, {:path_canonicalize_failed, path, reason}} ->
+        {:error, {:sync_workpad, "cannot resolve `#{path}`: #{inspect(reason)}."}}
+    end
+  end
+
+  defp path_within?(path, root) do
+    path_segments = comparable_path_segments(path)
+    root_segments = comparable_path_segments(root)
+
+    Enum.take(path_segments, length(root_segments)) == root_segments
+  end
+
+  defp comparable_path_segments(path) do
+    path
+    |> Path.expand()
+    |> Path.split()
+    |> Enum.map(&comparable_path_segment/1)
+  end
+
+  defp comparable_path_segment(segment) do
+    if match?({:win32, _}, :os.type()) do
+      String.downcase(segment)
+    else
+      segment
+    end
+  end
+
+  defp resolve_github_repo(sync_args) do
+    owner = sync_args.owner || configured_github_value(:owner)
+    repo = sync_args.repo || configured_github_value(:repo)
+
+    cond do
+      not present_string?(owner) ->
+        {:error, {:sync_workpad, "GitHub `owner` is required for creating a workpad comment."}}
+
+      not present_string?(repo) ->
+        {:error, {:sync_workpad, "GitHub `repo` is required for creating a workpad comment."}}
+
+      true ->
+        {:ok, String.trim(owner), String.trim(repo)}
+    end
+  end
+
+  defp configured_github_value(field) do
+    try do
+      Config.settings!().tracker
+      |> Map.get(field)
+      |> present_string_or_nil()
+    rescue
+      _ -> nil
+    end
+  end
+
+  defp present_string?(value), do: is_binary(value) and String.trim(value) != ""
+
+  defp present_string_or_nil(value) do
+    if present_string?(value), do: String.trim(value)
+  end
+
+  defp graphql_response(response) do
+    dynamic_tool_response(graphql_success?(response), encode_payload(response))
+  end
+
+  defp graphql_success?(response) do
+    case response do
+      %{"errors" => errors} when is_list(errors) and errors != [] -> false
+      %{errors: errors} when is_list(errors) and errors != [] -> false
+      _ -> true
+    end
   end
 
   defp failure_response(payload) do
@@ -144,7 +700,7 @@ defmodule SymphonyElixir.Codex.DynamicTool do
 
   defp encode_payload(payload), do: inspect(payload)
 
-  defp tool_error_payload(:missing_query) do
+  defp graphql_argument_error_payload(@linear_graphql_tool, :missing_query) do
     %{
       "error" => %{
         "message" => "`linear_graphql` requires a non-empty `query` string."
@@ -152,7 +708,15 @@ defmodule SymphonyElixir.Codex.DynamicTool do
     }
   end
 
-  defp tool_error_payload(:invalid_arguments) do
+  defp graphql_argument_error_payload(@github_graphql_tool, :missing_query) do
+    %{
+      "error" => %{
+        "message" => "`github_graphql` requires a non-empty `query` string."
+      }
+    }
+  end
+
+  defp graphql_argument_error_payload(@linear_graphql_tool, :invalid_arguments) do
     %{
       "error" => %{
         "message" => "`linear_graphql` expects either a GraphQL query string or an object with `query` and optional `variables`."
@@ -160,7 +724,15 @@ defmodule SymphonyElixir.Codex.DynamicTool do
     }
   end
 
-  defp tool_error_payload(:invalid_variables) do
+  defp graphql_argument_error_payload(@github_graphql_tool, :invalid_arguments) do
+    %{
+      "error" => %{
+        "message" => "`github_graphql` expects either a GraphQL query string or an object with `query` and optional `variables`."
+      }
+    }
+  end
+
+  defp graphql_argument_error_payload(@linear_graphql_tool, :invalid_variables) do
     %{
       "error" => %{
         "message" => "`linear_graphql.variables` must be a JSON object when provided."
@@ -168,7 +740,15 @@ defmodule SymphonyElixir.Codex.DynamicTool do
     }
   end
 
-  defp tool_error_payload(:missing_linear_api_token) do
+  defp graphql_argument_error_payload(@github_graphql_tool, :invalid_variables) do
+    %{
+      "error" => %{
+        "message" => "`github_graphql.variables` must be a JSON object when provided."
+      }
+    }
+  end
+
+  defp graphql_transport_error_payload(@linear_graphql_tool, :missing_linear_api_token) do
     %{
       "error" => %{
         "message" => "Symphony is missing Linear auth. Set `linear.api_key` in `WORKFLOW.md` or export `LINEAR_API_KEY`."
@@ -176,7 +756,51 @@ defmodule SymphonyElixir.Codex.DynamicTool do
     }
   end
 
-  defp tool_error_payload({:linear_api_status, status}) do
+  defp graphql_transport_error_payload(@github_graphql_tool, :missing_github_api_token) do
+    %{
+      "error" => %{
+        "message" => "Symphony is missing GitHub auth. Set `tracker.api_key` in `WORKFLOW.md` or export `GITHUB_TOKEN`."
+      }
+    }
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, :github_tracker_not_configured) do
+    %{
+      "error" => %{
+        "message" => "`github_graphql` is available only when `tracker.kind` is `github`."
+      }
+    }
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, :missing_github_token) do
+    graphql_transport_error_payload(@github_graphql_tool, :missing_github_api_token)
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_graphql_request, :missing_github_api_token}) do
+    graphql_transport_error_payload(@github_graphql_tool, :missing_github_api_token)
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_graphql_request, :missing_github_token}) do
+    graphql_transport_error_payload(@github_graphql_tool, :missing_github_api_token)
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_graphql_request, :github_tracker_not_configured}) do
+    graphql_transport_error_payload(@github_graphql_tool, :github_tracker_not_configured)
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_api_request, :missing_github_api_token}) do
+    graphql_transport_error_payload(@github_graphql_tool, :missing_github_api_token)
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_api_request, :github_tracker_not_configured}) do
+    graphql_transport_error_payload(@github_graphql_tool, :github_tracker_not_configured)
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_graphql_errors, errors}) do
+    %{"errors" => errors}
+  end
+
+  defp graphql_transport_error_payload(@linear_graphql_tool, {:linear_api_status, status}) do
     %{
       "error" => %{
         "message" => "Linear GraphQL request failed with HTTP #{status}.",
@@ -185,7 +809,30 @@ defmodule SymphonyElixir.Codex.DynamicTool do
     }
   end
 
-  defp tool_error_payload({:linear_api_request, reason}) do
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_api_status, status}) do
+    %{
+      "error" => %{
+        "message" => "GitHub GraphQL request failed with HTTP #{status}.",
+        "status" => status
+      }
+    }
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_graphql_status, status, body}) do
+    %{
+      "error" => %{
+        "message" => "GitHub GraphQL request failed with HTTP #{status}.",
+        "status" => status,
+        "body" => body
+      }
+    }
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_graphql_status, status}) do
+    graphql_transport_error_payload(@github_graphql_tool, {:github_api_status, status})
+  end
+
+  defp graphql_transport_error_payload(@linear_graphql_tool, {:linear_api_request, reason}) do
     %{
       "error" => %{
         "message" => "Linear GraphQL request failed before receiving a successful response.",
@@ -194,10 +841,49 @@ defmodule SymphonyElixir.Codex.DynamicTool do
     }
   end
 
-  defp tool_error_payload(reason) do
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_api_request, reason}) do
+    %{
+      "error" => %{
+        "message" => "GitHub GraphQL request failed before receiving a successful response.",
+        "reason" => inspect(reason)
+      }
+    }
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, {:github_graphql_request, reason}) do
+    graphql_transport_error_payload(@github_graphql_tool, {:github_api_request, reason})
+  end
+
+  defp graphql_transport_error_payload(@linear_graphql_tool, reason) do
     %{
       "error" => %{
         "message" => "Linear GraphQL tool execution failed.",
+        "reason" => inspect(reason)
+      }
+    }
+  end
+
+  defp graphql_transport_error_payload(@github_graphql_tool, reason) do
+    %{
+      "error" => %{
+        "message" => "GitHub GraphQL tool execution failed.",
+        "reason" => inspect(reason)
+      }
+    }
+  end
+
+  defp sync_workpad_error_payload({:sync_workpad, message}) do
+    %{
+      "error" => %{
+        "message" => "sync_workpad: #{message}"
+      }
+    }
+  end
+
+  defp sync_workpad_error_payload(reason) do
+    %{
+      "error" => %{
+        "message" => "sync_workpad failed.",
         "reason" => inspect(reason)
       }
     }

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -7,7 +7,7 @@ defmodule SymphonyElixir.Config do
   alias SymphonyElixir.Workflow
 
   @default_prompt_template """
-  You are working on a Linear issue.
+  You are working on an issue from the configured tracker.
 
   Identifier: {{ issue.identifier }}
   Title: {{ issue.title }}
@@ -119,7 +119,7 @@ defmodule SymphonyElixir.Config do
       is_nil(settings.tracker.kind) ->
         {:error, :missing_tracker_kind}
 
-      settings.tracker.kind not in ["linear", "memory"] ->
+      settings.tracker.kind not in ["linear", "github", "memory"] ->
         {:error, {:unsupported_tracker_kind, settings.tracker.kind}}
 
       settings.tracker.kind == "linear" and not is_binary(settings.tracker.api_key) ->
@@ -127,6 +127,25 @@ defmodule SymphonyElixir.Config do
 
       settings.tracker.kind == "linear" and not is_binary(settings.tracker.project_slug) ->
         {:error, :missing_linear_project_slug}
+
+      settings.tracker.kind == "github" and not is_binary(settings.tracker.api_key) ->
+        {:error, :missing_github_api_token}
+
+      settings.tracker.kind == "github" and not is_binary(settings.tracker.owner) ->
+        {:error, :missing_github_owner}
+
+      settings.tracker.kind == "github" and not is_binary(settings.tracker.repo) ->
+        {:error, :missing_github_repo}
+
+      settings.tracker.kind == "github" and not is_binary(settings.tracker.project_owner) ->
+        {:error, :missing_github_project_owner}
+
+      settings.tracker.kind == "github" and
+          settings.tracker.project_owner_type not in ["user", "organization", "org"] ->
+        {:error, {:unsupported_github_project_owner_type, settings.tracker.project_owner_type}}
+
+      settings.tracker.kind == "github" and not is_integer(settings.tracker.project_number) ->
+        {:error, :missing_github_project_number}
 
       true ->
         :ok

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -111,7 +111,7 @@ defmodule SymphonyElixir.Config.Schema do
 
     @primary_key false
     embedded_schema do
-      field(:root, :string, default: Path.join(System.tmp_dir!(), "symphony_workspaces"))
+      field(:root, :string)
     end
 
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
@@ -443,6 +443,8 @@ defmodule SymphonyElixir.Config.Schema do
       resolved -> resolved
     end
   end
+
+  defp resolve_path_value(nil, default), do: default
 
   defp resolve_path_value(value, default) when is_binary(value) do
     case normalize_path_token(value) do

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -49,6 +49,12 @@ defmodule SymphonyElixir.Config.Schema do
       field(:endpoint, :string, default: "https://api.linear.app/graphql")
       field(:api_key, :string)
       field(:project_slug, :string)
+      field(:owner, :string)
+      field(:repo, :string)
+      field(:project_owner, :string)
+      field(:project_owner_type, :string, default: "user")
+      field(:project_number, :integer)
+      field(:project_status_field, :string, default: "Status")
       field(:assignee, :string)
       field(:active_states, {:array, :string}, default: ["Todo", "In Progress"])
       field(:terminal_states, {:array, :string}, default: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"])
@@ -59,9 +65,24 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:kind, :endpoint, :api_key, :project_slug, :assignee, :active_states, :terminal_states],
+        [
+          :kind,
+          :endpoint,
+          :api_key,
+          :project_slug,
+          :owner,
+          :repo,
+          :project_owner,
+          :project_owner_type,
+          :project_number,
+          :project_status_field,
+          :assignee,
+          :active_states,
+          :terminal_states
+        ],
         empty_values: []
       )
+      |> validate_number(:project_number, greater_than: 0)
     end
   end
 
@@ -368,7 +389,8 @@ defmodule SymphonyElixir.Config.Schema do
   defp finalize_settings(settings) do
     tracker = %{
       settings.tracker
-      | api_key: resolve_secret_setting(settings.tracker.api_key, System.get_env("LINEAR_API_KEY")),
+      | endpoint: default_tracker_endpoint(settings.tracker.kind, settings.tracker.endpoint),
+        api_key: resolve_secret_setting(settings.tracker.api_key, default_tracker_api_key(settings.tracker.kind)),
         assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env("LINEAR_ASSIGNEE"))
     }
 
@@ -478,6 +500,15 @@ defmodule SymphonyElixir.Config.Schema do
   end
 
   defp normalize_secret_value(_value), do: nil
+
+  defp default_tracker_api_key("github"), do: System.get_env("GITHUB_TOKEN")
+  defp default_tracker_api_key(_kind), do: System.get_env("LINEAR_API_KEY")
+
+  defp default_tracker_endpoint("github", endpoint)
+       when endpoint in [nil, "", "https://api.linear.app/graphql"],
+       do: "https://api.github.com"
+
+  defp default_tracker_endpoint(_kind, endpoint), do: endpoint
 
   defp default_turn_sandbox_policy(workspace) do
     %{

--- a/elixir/lib/symphony_elixir/github/adapter.ex
+++ b/elixir/lib/symphony_elixir/github/adapter.ex
@@ -1,0 +1,40 @@
+defmodule SymphonyElixir.GitHub.Adapter do
+  @moduledoc """
+  GitHub-backed tracker adapter.
+  """
+
+  @behaviour SymphonyElixir.Tracker
+
+  alias SymphonyElixir.GitHub.Client
+
+  @spec fetch_candidate_issues() :: {:ok, [term()]} | {:error, term()}
+  def fetch_candidate_issues, do: client_module().fetch_candidate_issues()
+
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [term()]} | {:error, term()}
+  def fetch_issues_by_states(states), do: client_module().fetch_issues_by_states(states)
+
+  @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
+  def fetch_issue_states_by_ids(issue_ids), do: client_module().fetch_issue_states_by_ids(issue_ids)
+
+  @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
+  def create_comment(issue_id, body) when is_binary(issue_id) and is_binary(body) do
+    client_module().create_comment(issue_id, body)
+  end
+
+  @spec update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
+  def update_issue_state(issue_id, state_name)
+      when is_binary(issue_id) and is_binary(state_name) do
+    with {:ok, status_update} <- client_module().resolve_status_update(issue_id, state_name),
+         :ok <- client_module().update_project_item_status(status_update),
+         :ok <- client_module().patch_issue_state(issue_id, state_name) do
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :github_issue_update_failed}
+    end
+  end
+
+  defp client_module do
+    Application.get_env(:symphony_elixir, :github_client_module, Client)
+  end
+end

--- a/elixir/lib/symphony_elixir/github/client.ex
+++ b/elixir/lib/symphony_elixir/github/client.ex
@@ -1,0 +1,1018 @@
+defmodule SymphonyElixir.GitHub.Client do
+  @moduledoc """
+  GitHub Issues and Projects v2 client for the tracker adapter.
+  """
+
+  require Logger
+  alias SymphonyElixir.{Config, Tracker.Issue}
+
+  @api_version "2026-03-10"
+  @project_page_size 50
+  @field_page_size 50
+  @max_error_body_log_bytes 1_000
+
+  @project_items_query_user """
+  query SymphonyGitHubProjectItems($owner: String!, $number: Int!, $statusFieldName: String!, $first: Int!, $after: String) {
+    user(login: $owner) {
+      projectV2(number: $number) {
+        id
+        items(first: $first, after: $after) {
+          nodes {
+            id
+            content {
+              __typename
+              ... on Issue {
+                id
+                number
+                title
+                body
+                state
+                url
+                createdAt
+                updatedAt
+                repository {
+                  name
+                  owner {
+                    login
+                  }
+                }
+                assignees(first: 10) {
+                  nodes {
+                    login
+                  }
+                }
+                labels(first: 50) {
+                  nodes {
+                    name
+                  }
+                }
+              }
+              ... on PullRequest {
+                id
+                number
+              }
+            }
+            fieldValueByName(name: $statusFieldName) {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                optionId
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+  """
+
+  @project_items_query_organization """
+  query SymphonyGitHubProjectItems($owner: String!, $number: Int!, $statusFieldName: String!, $first: Int!, $after: String) {
+    organization(login: $owner) {
+      projectV2(number: $number) {
+        id
+        items(first: $first, after: $after) {
+          nodes {
+            id
+            content {
+              __typename
+              ... on Issue {
+                id
+                number
+                title
+                body
+                state
+                url
+                createdAt
+                updatedAt
+                repository {
+                  name
+                  owner {
+                    login
+                  }
+                }
+                assignees(first: 10) {
+                  nodes {
+                    login
+                  }
+                }
+                labels(first: 50) {
+                  nodes {
+                    name
+                  }
+                }
+              }
+              ... on PullRequest {
+                id
+                number
+              }
+            }
+            fieldValueByName(name: $statusFieldName) {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                optionId
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+  """
+
+  @project_fields_query_user """
+  query SymphonyGitHubProjectFields($owner: String!, $number: Int!, $first: Int!, $after: String) {
+    user(login: $owner) {
+      projectV2(number: $number) {
+        id
+        fields(first: $first, after: $after) {
+          nodes {
+            __typename
+            ... on ProjectV2FieldCommon {
+              id
+              name
+              dataType
+            }
+            ... on ProjectV2SingleSelectField {
+              options {
+                id
+                name
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+  """
+
+  @project_fields_query_organization """
+  query SymphonyGitHubProjectFields($owner: String!, $number: Int!, $first: Int!, $after: String) {
+    organization(login: $owner) {
+      projectV2(number: $number) {
+        id
+        fields(first: $first, after: $after) {
+          nodes {
+            __typename
+            ... on ProjectV2FieldCommon {
+              id
+              name
+              dataType
+            }
+            ... on ProjectV2SingleSelectField {
+              options {
+                id
+                name
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+  """
+
+  @update_project_status_mutation """
+  mutation SymphonyGitHubUpdateProjectStatus($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $fieldId
+      value: { singleSelectOptionId: $optionId }
+    }) {
+      projectV2Item {
+        id
+      }
+    }
+  }
+  """
+
+  @spec fetch_candidate_issues() :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_candidate_issues do
+    tracker = Config.settings!().tracker
+
+    with :ok <- validate_tracker_settings(tracker),
+         {:ok, issues} <- fetch_project_issues(&graphql/2) do
+      {:ok, filter_issues_by_states(issues, tracker.active_states)}
+    end
+  end
+
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_states(state_names) when is_list(state_names) do
+    states =
+      state_names
+      |> Enum.map(&to_string/1)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.uniq()
+
+    if states == [] do
+      {:ok, []}
+    else
+      tracker = Config.settings!().tracker
+
+      with :ok <- validate_tracker_settings(tracker),
+           {:ok, issues} <- fetch_project_issues(&graphql/2) do
+        {:ok, filter_issues_by_states(issues, states)}
+      end
+    end
+  end
+
+  @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issue_states_by_ids(issue_ids) when is_list(issue_ids) do
+    ids =
+      issue_ids
+      |> Enum.map(&to_string/1)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.uniq()
+
+    if ids == [] do
+      {:ok, []}
+    else
+      with :ok <- validate_tracker_settings(Config.settings!().tracker),
+           {:ok, issues} <- fetch_project_issues(&graphql/2) do
+        {:ok,
+         issues
+         |> Enum.filter(fn %Issue{id: id} -> id in ids end)
+         |> sort_issues_by_requested_ids(issue_order_index(ids))}
+      end
+    end
+  end
+
+  @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
+  def create_comment(issue_id, body) when is_binary(issue_id) and is_binary(body) do
+    create_comment(issue_id, body, &request/5)
+  end
+
+  @spec patch_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
+  def patch_issue_state(issue_id, state_name) when is_binary(issue_id) and is_binary(state_name) do
+    patch_issue_state(issue_id, state_name, &request/5)
+  end
+
+  @spec resolve_status_update(String.t(), String.t()) :: {:ok, map()} | {:error, term()}
+  def resolve_status_update(issue_id, state_name) when is_binary(issue_id) and is_binary(state_name) do
+    resolve_status_update(issue_id, state_name, &graphql/2)
+  end
+
+  @spec update_project_item_status(map()) :: :ok | {:error, term()}
+  def update_project_item_status(%{
+        project_id: project_id,
+        item_id: item_id,
+        field_id: field_id,
+        option_id: option_id
+      })
+      when is_binary(project_id) and is_binary(item_id) and is_binary(field_id) and is_binary(option_id) do
+    with {:ok, response} <-
+           graphql(@update_project_status_mutation, %{
+             projectId: project_id,
+             itemId: item_id,
+             fieldId: field_id,
+             optionId: option_id
+           }),
+         updated_item_id when is_binary(updated_item_id) <-
+           get_in(response, ["data", "updateProjectV2ItemFieldValue", "projectV2Item", "id"]) do
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :github_project_status_update_failed}
+    end
+  end
+
+  @spec graphql(String.t(), map(), keyword()) :: {:ok, map()} | {:error, term()}
+  def graphql(query, variables \\ %{}, opts \\ [])
+      when is_binary(query) and is_map(variables) and is_list(opts) do
+    payload = build_graphql_payload(query, variables, Keyword.get(opts, :operation_name))
+    request_fun = Keyword.get(opts, :request_fun, &post_graphql_request/2)
+
+    with {:ok, headers} <- github_headers(),
+         {:ok, %{status: 200, body: body}} <- request_fun.(payload, headers),
+         :ok <- reject_graphql_errors(body) do
+      {:ok, body}
+    else
+      {:ok, response} ->
+        status = response_status(response)
+        error_body = summarize_error_body(response_body(response))
+
+        Logger.error(
+          "GitHub GraphQL request failed status=#{status}" <>
+            github_error_context(payload, error_body)
+        )
+
+        {:error, {:github_graphql_status, status, error_body}}
+
+      {:error, {:github_graphql_errors, errors}} ->
+        Logger.error("GitHub GraphQL request failed errors=#{inspect(errors, limit: 20)}")
+        {:error, {:github_graphql_errors, errors}}
+
+      {:error, reason} ->
+        Logger.error("GitHub GraphQL request failed: #{inspect(reason)}")
+        {:error, {:github_graphql_request, reason}}
+    end
+  end
+
+  @doc false
+  @spec fetch_candidate_issues_for_test((String.t(), map() -> {:ok, map()} | {:error, term()})) ::
+          {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_candidate_issues_for_test(graphql_fun) when is_function(graphql_fun, 2) do
+    tracker = Config.settings!().tracker
+
+    with :ok <- validate_tracker_settings(tracker),
+         {:ok, issues} <- fetch_project_issues(graphql_fun) do
+      {:ok, filter_issues_by_states(issues, tracker.active_states)}
+    end
+  end
+
+  @doc false
+  @spec fetch_issues_by_states_for_test([String.t()], (String.t(), map() -> {:ok, map()} | {:error, term()})) ::
+          {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_states_for_test(states, graphql_fun)
+      when is_list(states) and is_function(graphql_fun, 2) do
+    with :ok <- validate_tracker_settings(Config.settings!().tracker),
+         {:ok, issues} <- fetch_project_issues(graphql_fun) do
+      {:ok, filter_issues_by_states(issues, states)}
+    end
+  end
+
+  @doc false
+  @spec fetch_issue_states_by_ids_for_test([String.t()], (String.t(), map() -> {:ok, map()} | {:error, term()})) ::
+          {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issue_states_by_ids_for_test(issue_ids, graphql_fun)
+      when is_list(issue_ids) and is_function(graphql_fun, 2) do
+    ids =
+      issue_ids
+      |> Enum.map(&to_string/1)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.uniq()
+
+    if ids == [] do
+      {:ok, []}
+    else
+      with :ok <- validate_tracker_settings(Config.settings!().tracker),
+           {:ok, issues} <- fetch_project_issues(graphql_fun) do
+        {:ok,
+         issues
+         |> Enum.filter(fn %Issue{id: id} -> id in ids end)
+         |> sort_issues_by_requested_ids(issue_order_index(ids))}
+      end
+    end
+  end
+
+  @doc false
+  @spec resolve_status_update_for_test(String.t(), String.t(), (String.t(), map() -> {:ok, map()} | {:error, term()})) ::
+          {:ok, map()} | {:error, term()}
+  def resolve_status_update_for_test(issue_id, state_name, graphql_fun)
+      when is_binary(issue_id) and is_binary(state_name) and is_function(graphql_fun, 2) do
+    resolve_status_update(issue_id, state_name, graphql_fun)
+  end
+
+  @doc false
+  @spec create_comment_for_test(String.t(), String.t(), (atom(), String.t(), list(), map() | nil, keyword() ->
+          {:ok, map()} | {:error, term()})) :: :ok | {:error, term()}
+  def create_comment_for_test(issue_id, body, request_fun)
+      when is_binary(issue_id) and is_binary(body) and is_function(request_fun, 5) do
+    create_comment(issue_id, body, request_fun)
+  end
+
+  @doc false
+  @spec patch_issue_state_for_test(String.t(), String.t(), (atom(), String.t(), list(), map() | nil, keyword() ->
+          {:ok, map()} | {:error, term()})) :: :ok | {:error, term()}
+  def patch_issue_state_for_test(issue_id, state_name, request_fun)
+      when is_binary(issue_id) and is_binary(state_name) and is_function(request_fun, 5) do
+    patch_issue_state(issue_id, state_name, request_fun)
+  end
+
+  defp fetch_project_issues(graphql_fun) when is_function(graphql_fun, 2) do
+    with {:ok, _project_id, items} <- fetch_project_items(graphql_fun) do
+      tracker = Config.settings!().tracker
+
+      issues =
+        items
+        |> Enum.map(&normalize_project_item(&1, tracker))
+        |> Enum.reject(&is_nil/1)
+
+      {:ok, issues}
+    end
+  end
+
+  defp fetch_project_items(graphql_fun) when is_function(graphql_fun, 2) do
+    tracker = Config.settings!().tracker
+
+    with :ok <- validate_tracker_settings(tracker),
+         {:ok, owner_key, query} <- project_items_query(tracker.project_owner_type) do
+      do_fetch_project_items_page(query, owner_key, tracker, graphql_fun, nil, nil, [])
+    end
+  end
+
+  defp do_fetch_project_items_page(query, owner_key, tracker, graphql_fun, after_cursor, project_id, acc_items) do
+    variables = %{
+      owner: tracker.project_owner,
+      number: tracker.project_number,
+      statusFieldName: tracker.project_status_field,
+      first: @project_page_size,
+      after: after_cursor
+    }
+
+    with {:ok, body} <- graphql_fun.(query, variables),
+         {:ok, page_project_id, items, page_info} <- decode_project_items_response(body, owner_key) do
+      updated_project_id = project_id || page_project_id
+      updated_items = prepend_page_items(items, acc_items)
+
+      case next_page_cursor(page_info, :github_missing_project_item_end_cursor) do
+        {:ok, next_cursor} ->
+          do_fetch_project_items_page(
+            query,
+            owner_key,
+            tracker,
+            graphql_fun,
+            next_cursor,
+            updated_project_id,
+            updated_items
+          )
+
+        :done ->
+          {:ok, updated_project_id, finalize_paginated_items(updated_items)}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp fetch_project_status_field(graphql_fun) when is_function(graphql_fun, 2) do
+    tracker = Config.settings!().tracker
+
+    with :ok <- validate_tracker_settings(tracker),
+         {:ok, owner_key, query} <- project_fields_query(tracker.project_owner_type),
+         {:ok, project_id, fields} <-
+           do_fetch_project_fields_page(query, owner_key, tracker, graphql_fun, nil, nil, []) do
+      fields
+      |> Enum.find(fn field -> normalized(field["name"]) == normalized(tracker.project_status_field) end)
+      |> case do
+        nil -> {:error, {:github_project_status_field_not_found, tracker.project_status_field}}
+        field -> {:ok, %{project_id: project_id, field: field}}
+      end
+    end
+  end
+
+  defp do_fetch_project_fields_page(query, owner_key, tracker, graphql_fun, after_cursor, project_id, acc_fields) do
+    variables = %{
+      owner: tracker.project_owner,
+      number: tracker.project_number,
+      first: @field_page_size,
+      after: after_cursor
+    }
+
+    with {:ok, body} <- graphql_fun.(query, variables),
+         {:ok, page_project_id, fields, page_info} <- decode_project_fields_response(body, owner_key) do
+      updated_project_id = project_id || page_project_id
+      updated_fields = prepend_page_items(fields, acc_fields)
+
+      case next_page_cursor(page_info, :github_missing_project_field_end_cursor) do
+        {:ok, next_cursor} ->
+          do_fetch_project_fields_page(
+            query,
+            owner_key,
+            tracker,
+            graphql_fun,
+            next_cursor,
+            updated_project_id,
+            updated_fields
+          )
+
+        :done ->
+          {:ok, updated_project_id, finalize_paginated_items(updated_fields)}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp resolve_status_update(issue_id, state_name, graphql_fun) when is_function(graphql_fun, 2) do
+    tracker = Config.settings!().tracker
+
+    with {:ok, issue_number} <- parse_issue_number(issue_id),
+         {:ok, %{project_id: project_id, field: field}} <- fetch_project_status_field(graphql_fun),
+         {:ok, option_id} <- status_option_id(field, state_name),
+         {:ok, _project_id, items} <- fetch_project_items(graphql_fun),
+         {:ok, item_id} <- project_item_id_for_issue(items, issue_number, tracker) do
+      {:ok,
+       %{
+         project_id: project_id,
+         item_id: item_id,
+         field_id: field["id"],
+         option_id: option_id,
+         state_name: state_name
+       }}
+    end
+  end
+
+  defp status_option_id(field, state_name) when is_map(field) do
+    option =
+      field
+      |> Map.get("options", [])
+      |> Enum.find(fn option -> normalized(option["name"]) == normalized(state_name) end)
+
+    case option do
+      %{"id" => option_id} when is_binary(option_id) ->
+        {:ok, option_id}
+
+      _ ->
+        {:error, {:github_project_status_option_not_found, field["name"], state_name}}
+    end
+  end
+
+  defp project_item_id_for_issue(items, issue_number, tracker) when is_list(items) and is_integer(issue_number) do
+    items
+    |> Enum.find(fn
+      %{"id" => item_id, "content" => %{"__typename" => "Issue", "number" => number} = issue}
+      when is_binary(item_id) ->
+        number == issue_number and repository_matches?(issue, tracker)
+
+      _ ->
+        false
+    end)
+    |> case do
+      %{"id" => item_id} -> {:ok, item_id}
+      _ -> {:error, {:github_project_item_not_found, Integer.to_string(issue_number)}}
+    end
+  end
+
+  defp create_comment(issue_id, body, request_fun) when is_function(request_fun, 5) do
+    with {:ok, issue_number} <- parse_issue_number(issue_id),
+         :ok <- validate_tracker_settings(Config.settings!().tracker),
+         {:ok, %{status: 201}} <-
+           request_fun.(
+             :post,
+             repository_issue_path(issue_number) <> "/comments",
+             github_headers!(),
+             %{"body" => body},
+             []
+           ) do
+      :ok
+    else
+      {:ok, response} ->
+        {:error,
+         {:github_comment_create_status, response_status(response),
+          summarize_error_body(response_body(response))}}
+
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp patch_issue_state(issue_id, state_name, request_fun) when is_function(request_fun, 5) do
+    tracker = Config.settings!().tracker
+
+    with {:ok, issue_number} <- parse_issue_number(issue_id),
+         :ok <- validate_tracker_settings(tracker),
+         {:ok, %{status: 200}} <-
+           request_fun.(
+             :patch,
+             repository_issue_path(issue_number),
+             github_headers!(),
+             issue_state_patch_payload(state_name, tracker),
+             []
+           ) do
+      :ok
+    else
+      {:ok, response} ->
+        {:error,
+         {:github_issue_patch_status, response_status(response),
+          summarize_error_body(response_body(response))}}
+
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp issue_state_patch_payload(state_name, tracker) do
+    if terminal_state?(state_name, tracker) do
+      %{"state" => "closed", "state_reason" => closed_state_reason(state_name)}
+    else
+      %{"state" => "open", "state_reason" => "reopened"}
+    end
+  end
+
+  defp closed_state_reason(state_name) do
+    case normalized(state_name) do
+      "duplicate" -> "duplicate"
+      "cancelled" -> "not_planned"
+      "canceled" -> "not_planned"
+      "not planned" -> "not_planned"
+      "not_planned" -> "not_planned"
+      _ -> "completed"
+    end
+  end
+
+  defp request(method, path, headers, json, params) do
+    opts =
+      [
+        method: method,
+        url: github_rest_url(path),
+        headers: headers,
+        connect_options: [timeout: 30_000]
+      ]
+      |> maybe_put_request_option(:json, json)
+      |> maybe_put_request_option(:params, params)
+
+    Req.request(opts)
+  end
+
+  defp maybe_put_request_option(opts, _key, nil), do: opts
+  defp maybe_put_request_option(opts, _key, []), do: opts
+  defp maybe_put_request_option(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp repository_issue_path(issue_number) when is_integer(issue_number) do
+    tracker = Config.settings!().tracker
+    "/repos/#{path_segment(tracker.owner)}/#{path_segment(tracker.repo)}/issues/#{issue_number}"
+  end
+
+  defp github_rest_url(path) when is_binary(path) do
+    endpoint =
+      Config.settings!().tracker.endpoint
+      |> String.trim_trailing("/")
+
+    endpoint <> path
+  end
+
+  defp validate_tracker_settings(tracker) do
+    cond do
+      tracker.kind != "github" -> {:error, :github_tracker_not_configured}
+      not is_binary(tracker.api_key) -> {:error, :missing_github_api_token}
+      not is_binary(tracker.owner) -> {:error, :missing_github_owner}
+      not is_binary(tracker.repo) -> {:error, :missing_github_repo}
+      not is_binary(tracker.project_owner) -> {:error, :missing_github_project_owner}
+      not is_integer(tracker.project_number) -> {:error, :missing_github_project_number}
+      not is_binary(tracker.project_status_field) -> {:error, :missing_github_project_status_field}
+      true -> :ok
+    end
+  end
+
+  defp project_items_query(owner_type) do
+    case normalized(owner_type || "user") do
+      "user" -> {:ok, "user", @project_items_query_user}
+      "organization" -> {:ok, "organization", @project_items_query_organization}
+      "org" -> {:ok, "organization", @project_items_query_organization}
+      other -> {:error, {:unsupported_github_project_owner_type, other}}
+    end
+  end
+
+  defp project_fields_query(owner_type) do
+    case normalized(owner_type || "user") do
+      "user" -> {:ok, "user", @project_fields_query_user}
+      "organization" -> {:ok, "organization", @project_fields_query_organization}
+      "org" -> {:ok, "organization", @project_fields_query_organization}
+      other -> {:error, {:unsupported_github_project_owner_type, other}}
+    end
+  end
+
+  defp decode_project_items_response(%{"errors" => errors}, _owner_key), do: {:error, {:github_graphql_errors, errors}}
+
+  defp decode_project_items_response(%{"data" => data}, owner_key) when is_map(data) do
+    case get_in(data, [owner_key, "projectV2"]) do
+      %{
+        "id" => project_id,
+        "items" => %{
+          "nodes" => items,
+          "pageInfo" => %{"hasNextPage" => has_next_page, "endCursor" => end_cursor}
+        }
+      }
+      when is_list(items) ->
+        {:ok, project_id, items, %{has_next_page: has_next_page == true, end_cursor: end_cursor}}
+
+      nil ->
+        {:error, :github_project_not_found}
+
+      _ ->
+        {:error, :github_unknown_project_items_payload}
+    end
+  end
+
+  defp decode_project_items_response(_response, _owner_key), do: {:error, :github_unknown_project_items_payload}
+
+  defp decode_project_fields_response(%{"errors" => errors}, _owner_key), do: {:error, {:github_graphql_errors, errors}}
+
+  defp decode_project_fields_response(%{"data" => data}, owner_key) when is_map(data) do
+    case get_in(data, [owner_key, "projectV2"]) do
+      %{
+        "id" => project_id,
+        "fields" => %{
+          "nodes" => fields,
+          "pageInfo" => %{"hasNextPage" => has_next_page, "endCursor" => end_cursor}
+        }
+      }
+      when is_list(fields) ->
+        {:ok, project_id, fields, %{has_next_page: has_next_page == true, end_cursor: end_cursor}}
+
+      nil ->
+        {:error, :github_project_not_found}
+
+      _ ->
+        {:error, :github_unknown_project_fields_payload}
+    end
+  end
+
+  defp decode_project_fields_response(_response, _owner_key), do: {:error, :github_unknown_project_fields_payload}
+
+  defp normalize_project_item(%{"content" => %{"__typename" => "Issue"} = issue} = item, tracker) do
+    if repository_matches?(issue, tracker) do
+      number = issue["number"]
+      status = project_status_name(item)
+      assignees = assignee_logins(issue)
+
+      %Issue{
+        id: issue_number_id(number),
+        identifier: issue_identifier(number, tracker),
+        title: issue["title"],
+        description: issue["body"],
+        priority: nil,
+        state: github_issue_state(issue, status, tracker),
+        branch_name: nil,
+        url: issue["url"],
+        assignee_id: List.first(assignees),
+        blocked_by: [],
+        labels: label_names(issue),
+        assigned_to_worker: true,
+        created_at: parse_datetime(issue["createdAt"]),
+        updated_at: parse_datetime(issue["updatedAt"])
+      }
+    end
+  end
+
+  defp normalize_project_item(_item, _tracker), do: nil
+
+  defp repository_matches?(issue, tracker) do
+    repository = issue["repository"] || %{}
+    owner = get_in(repository, ["owner", "login"])
+    repo = repository["name"]
+
+    normalized(owner) == normalized(tracker.owner) and normalized(repo) == normalized(tracker.repo)
+  end
+
+  defp project_status_name(%{"fieldValueByName" => %{"name" => name}}) when is_binary(name), do: name
+  defp project_status_name(_item), do: nil
+
+  defp github_issue_state(issue, project_status, tracker) do
+    if github_issue_closed?(issue) do
+      closed_issue_state(tracker)
+    else
+      project_status
+    end
+  end
+
+  defp github_issue_closed?(%{"state" => state}) when is_binary(state), do: normalized(state) == "closed"
+  defp github_issue_closed?(_issue), do: false
+
+  defp closed_issue_state(tracker) do
+    Enum.find(tracker.terminal_states, &(normalized(&1) == "closed")) || "Closed"
+  end
+
+  defp terminal_state?(state_name, tracker) do
+    terminal_states =
+      tracker.terminal_states
+      |> Enum.map(&normalized/1)
+      |> MapSet.new()
+
+    MapSet.member?(terminal_states, normalized(state_name))
+  end
+
+  defp filter_issues_by_states(issues, state_names) do
+    wanted_states =
+      state_names
+      |> Enum.map(&normalized/1)
+      |> Enum.reject(&(&1 == ""))
+      |> MapSet.new()
+
+    Enum.filter(issues, fn %Issue{state: state} ->
+      MapSet.member?(wanted_states, normalized(state))
+    end)
+  end
+
+  defp assignee_logins(%{"assignees" => %{"nodes" => assignees}}) when is_list(assignees) do
+    assignees
+    |> Enum.map(& &1["login"])
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp assignee_logins(_issue), do: []
+
+  defp label_names(%{"labels" => %{"nodes" => labels}}) when is_list(labels) do
+    labels
+    |> Enum.map(& &1["name"])
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&String.downcase/1)
+  end
+
+  defp label_names(_issue), do: []
+
+  defp issue_number_id(number) when is_integer(number), do: Integer.to_string(number)
+  defp issue_number_id(number) when is_binary(number), do: number
+  defp issue_number_id(_number), do: nil
+
+  defp issue_identifier(number, tracker) do
+    case issue_number_id(number) do
+      nil -> nil
+      issue_id -> "#{tracker.owner}/#{tracker.repo}##{issue_id}"
+    end
+  end
+
+  defp parse_issue_number(issue_id) when is_binary(issue_id) do
+    normalized_issue_id =
+      issue_id
+      |> String.trim()
+      |> String.trim_leading("#")
+
+    case Integer.parse(normalized_issue_id) do
+      {number, ""} when number > 0 -> {:ok, number}
+      _ -> {:error, {:invalid_github_issue_number, issue_id}}
+    end
+  end
+
+  defp issue_order_index(ids) when is_list(ids) do
+    ids
+    |> Enum.with_index()
+    |> Map.new()
+  end
+
+  defp sort_issues_by_requested_ids(issues, issue_order_index)
+       when is_list(issues) and is_map(issue_order_index) do
+    fallback_index = map_size(issue_order_index)
+
+    Enum.sort_by(issues, fn
+      %Issue{id: issue_id} -> Map.get(issue_order_index, issue_id, fallback_index)
+      _ -> fallback_index
+    end)
+  end
+
+  defp prepend_page_items(items, acc_items) when is_list(items) and is_list(acc_items) do
+    Enum.reverse(items, acc_items)
+  end
+
+  defp finalize_paginated_items(acc_items) when is_list(acc_items), do: Enum.reverse(acc_items)
+
+  defp next_page_cursor(%{has_next_page: true, end_cursor: end_cursor}, _error)
+       when is_binary(end_cursor) and byte_size(end_cursor) > 0 do
+    {:ok, end_cursor}
+  end
+
+  defp next_page_cursor(%{has_next_page: true}, error), do: {:error, error}
+  defp next_page_cursor(_page_info, _error), do: :done
+
+  defp build_graphql_payload(query, variables, operation_name) do
+    %{
+      "query" => query,
+      "variables" => variables
+    }
+    |> maybe_put_operation_name(operation_name)
+  end
+
+  defp maybe_put_operation_name(payload, operation_name) when is_binary(operation_name) do
+    trimmed = String.trim(operation_name)
+
+    if trimmed == "" do
+      payload
+    else
+      Map.put(payload, "operationName", trimmed)
+    end
+  end
+
+  defp maybe_put_operation_name(payload, _operation_name), do: payload
+
+  defp reject_graphql_errors(%{"errors" => errors}), do: {:error, {:github_graphql_errors, errors}}
+  defp reject_graphql_errors(_body), do: :ok
+
+  defp github_error_context(payload, error_body) when is_map(payload) do
+    operation_name =
+      case Map.get(payload, "operationName") do
+        name when is_binary(name) and name != "" -> " operation=#{name}"
+        _ -> ""
+      end
+
+    operation_name <> " body=" <> error_body
+  end
+
+  defp summarize_error_body(body) when is_binary(body) do
+    body
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+    |> truncate_error_body()
+    |> inspect()
+  end
+
+  defp summarize_error_body(body) do
+    body
+    |> inspect(limit: 20, printable_limit: @max_error_body_log_bytes)
+    |> truncate_error_body()
+  end
+
+  defp truncate_error_body(body) when is_binary(body) do
+    if byte_size(body) > @max_error_body_log_bytes do
+      binary_part(body, 0, @max_error_body_log_bytes) <> "...<truncated>"
+    else
+      body
+    end
+  end
+
+  defp github_headers do
+    tracker = Config.settings!().tracker
+
+    cond do
+      tracker.kind != "github" ->
+        {:error, :github_tracker_not_configured}
+
+      is_nil(tracker.api_key) ->
+        {:error, :missing_github_api_token}
+
+      true ->
+        {:ok,
+         [
+           {"Authorization", authorization_header(tracker.api_key)},
+           {"Accept", "application/vnd.github+json"},
+           {"Content-Type", "application/json"},
+           {"X-GitHub-Api-Version", @api_version}
+         ]}
+    end
+  end
+
+  defp authorization_header(token) when is_binary(token) do
+    if Regex.match?(~r/^(bearer|token)\s+/i, token) do
+      token
+    else
+      "Bearer #{token}"
+    end
+  end
+
+  defp github_headers! do
+    case github_headers() do
+      {:ok, headers} -> headers
+      {:error, reason} -> raise ArgumentError, message: inspect(reason)
+    end
+  end
+
+  defp post_graphql_request(payload, headers) do
+    Req.post(graphql_endpoint(),
+      headers: headers,
+      json: payload,
+      connect_options: [timeout: 30_000]
+    )
+  end
+
+  defp graphql_endpoint do
+    endpoint =
+      Config.settings!().tracker.endpoint
+      |> String.trim_trailing("/")
+
+    if String.ends_with?(endpoint, "/graphql") do
+      endpoint
+    else
+      endpoint <> "/graphql"
+    end
+  end
+
+  defp path_segment(value) when is_binary(value) do
+    URI.encode(value, &URI.char_unreserved?/1)
+  end
+
+  defp response_status(response) when is_map(response) do
+    Map.get(response, :status)
+  end
+
+  defp response_body(response) when is_map(response) do
+    Map.get(response, :body)
+  end
+
+  defp normalized(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.downcase()
+  end
+
+  defp normalized(value), do: value |> to_string() |> normalized()
+
+  defp parse_datetime(nil), do: nil
+
+  defp parse_datetime(raw) do
+    case DateTime.from_iso8601(raw) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/github/client.ex
+++ b/elixir/lib/symphony_elixir/github/client.ex
@@ -386,7 +386,7 @@ defmodule SymphonyElixir.GitHub.Client do
 
   @doc false
   @spec create_comment_for_test(String.t(), String.t(), (atom(), String.t(), list(), map() | nil, keyword() ->
-          {:ok, map()} | {:error, term()})) :: :ok | {:error, term()}
+                                                           {:ok, map()} | {:error, term()})) :: :ok | {:error, term()}
   def create_comment_for_test(issue_id, body, request_fun)
       when is_binary(issue_id) and is_binary(body) and is_function(request_fun, 5) do
     create_comment(issue_id, body, request_fun)
@@ -394,7 +394,7 @@ defmodule SymphonyElixir.GitHub.Client do
 
   @doc false
   @spec patch_issue_state_for_test(String.t(), String.t(), (atom(), String.t(), list(), map() | nil, keyword() ->
-          {:ok, map()} | {:error, term()})) :: :ok | {:error, term()}
+                                                              {:ok, map()} | {:error, term()})) :: :ok | {:error, term()}
   def patch_issue_state_for_test(issue_id, state_name, request_fun)
       when is_binary(issue_id) and is_binary(state_name) and is_function(request_fun, 5) do
     patch_issue_state(issue_id, state_name, request_fun)
@@ -571,11 +571,10 @@ defmodule SymphonyElixir.GitHub.Client do
       :ok
     else
       {:ok, response} ->
-        {:error,
-         {:github_comment_create_status, response_status(response),
-          summarize_error_body(response_body(response))}}
+        {:error, {:github_comment_create_status, response_status(response), summarize_error_body(response_body(response))}}
 
-      {:error, reason} -> {:error, reason}
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -595,11 +594,10 @@ defmodule SymphonyElixir.GitHub.Client do
       :ok
     else
       {:ok, response} ->
-        {:error,
-         {:github_issue_patch_status, response_status(response),
-          summarize_error_body(response_body(response))}}
+        {:error, {:github_issue_patch_status, response_status(response), summarize_error_body(response_body(response))}}
 
-      {:error, reason} -> {:error, reason}
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/elixir/lib/symphony_elixir/github/client.ex
+++ b/elixir/lib/symphony_elixir/github/client.ex
@@ -400,6 +400,10 @@ defmodule SymphonyElixir.GitHub.Client do
     patch_issue_state(issue_id, state_name, request_fun)
   end
 
+  @doc false
+  @spec github_rest_url_for_test(String.t()) :: String.t()
+  def github_rest_url_for_test(path) when is_binary(path), do: github_rest_url(path)
+
   defp fetch_project_issues(graphql_fun) when is_function(graphql_fun, 2) do
     with {:ok, _project_id, items} <- fetch_project_items(graphql_fun) do
       tracker = Config.settings!().tracker
@@ -646,9 +650,33 @@ defmodule SymphonyElixir.GitHub.Client do
   defp github_rest_url(path) when is_binary(path) do
     endpoint =
       Config.settings!().tracker.endpoint
-      |> String.trim_trailing("/")
+      |> rest_endpoint()
 
     endpoint <> path
+  end
+
+  defp rest_endpoint(endpoint) when is_binary(endpoint) do
+    endpoint
+    |> String.trim_trailing("/")
+    |> String.replace_suffix("/graphql", "")
+    |> String.trim_trailing("/")
+  end
+
+  defp issue_identifier(number, tracker) do
+    case issue_number_id(number) do
+      nil ->
+        nil
+
+      issue_id ->
+        [
+          "github",
+          identifier_segment(tracker.owner),
+          identifier_segment(tracker.repo),
+          identifier_segment(issue_id)
+        ]
+        |> Enum.reject(&(&1 == ""))
+        |> Enum.join("-")
+    end
   end
 
   defp validate_tracker_settings(tracker) do
@@ -825,13 +853,6 @@ defmodule SymphonyElixir.GitHub.Client do
   defp issue_number_id(number) when is_binary(number), do: number
   defp issue_number_id(_number), do: nil
 
-  defp issue_identifier(number, tracker) do
-    case issue_number_id(number) do
-      nil -> nil
-      issue_id -> "#{tracker.owner}/#{tracker.repo}##{issue_id}"
-    end
-  end
-
   defp parse_issue_number(issue_id) when is_binary(issue_id) do
     normalized_issue_id =
       issue_id
@@ -987,6 +1008,13 @@ defmodule SymphonyElixir.GitHub.Client do
 
   defp path_segment(value) when is_binary(value) do
     URI.encode(value, &URI.char_unreserved?/1)
+  end
+
+  defp identifier_segment(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.replace(~r/[^A-Za-z0-9._~-]+/, "-")
+    |> String.trim("-")
   end
 
   defp response_status(response) when is_map(response) do

--- a/elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/lib/symphony_elixir/linear/client.ex
@@ -4,7 +4,7 @@ defmodule SymphonyElixir.Linear.Client do
   """
 
   require Logger
-  alias SymphonyElixir.{Config, Linear.Issue}
+  alias SymphonyElixir.{Config, Tracker.Issue}
 
   @issue_page_size 50
   @max_error_body_log_bytes 1_000

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -1,6 +1,6 @@
 defmodule SymphonyElixir.Orchestrator do
   @moduledoc """
-  Polls Linear and dispatches repository copies to Codex-backed workers.
+  Polls the configured tracker and dispatches repository copies to Codex-backed workers.
   """
 
   use GenServer
@@ -8,7 +8,7 @@ defmodule SymphonyElixir.Orchestrator do
   import Bitwise, only: [<<<: 2]
 
   alias SymphonyElixir.{AgentRunner, Config, StatusDashboard, Tracker, Workspace}
-  alias SymphonyElixir.Linear.Issue
+  alias SymphonyElixir.Tracker.Issue
 
   @continuation_retry_delay_ms 1_000
   @failure_retry_base_ms 10_000

--- a/elixir/lib/symphony_elixir/path_safety.ex
+++ b/elixir/lib/symphony_elixir/path_safety.ex
@@ -23,24 +23,28 @@ defmodule SymphonyElixir.PathSafety do
   defp resolve_segments(root, resolved_segments, []), do: {:ok, join_path(root, resolved_segments)}
 
   defp resolve_segments(root, resolved_segments, [segment | rest]) do
-    candidate_path = join_path(root, resolved_segments ++ [segment])
+    if byte_size(segment) > 255 do
+      {:error, :enametoolong}
+    else
+      candidate_path = join_path(root, resolved_segments ++ [segment])
 
-    case File.lstat(candidate_path) do
-      {:ok, %File.Stat{type: :symlink}} ->
-        with {:ok, target} <- :file.read_link_all(String.to_charlist(candidate_path)) do
-          resolved_target = Path.expand(IO.chardata_to_string(target), join_path(root, resolved_segments))
-          {target_root, target_segments} = split_absolute_path(resolved_target)
-          resolve_segments(target_root, [], target_segments ++ rest)
-        end
+      case File.lstat(candidate_path) do
+        {:ok, %File.Stat{type: :symlink}} ->
+          with {:ok, target} <- :file.read_link_all(String.to_charlist(candidate_path)) do
+            resolved_target = Path.expand(IO.chardata_to_string(target), join_path(root, resolved_segments))
+            {target_root, target_segments} = split_absolute_path(resolved_target)
+            resolve_segments(target_root, [], target_segments ++ rest)
+          end
 
-      {:ok, _stat} ->
-        resolve_segments(root, resolved_segments ++ [segment], rest)
+        {:ok, _stat} ->
+          resolve_segments(root, resolved_segments ++ [segment], rest)
 
-      {:error, :enoent} ->
-        {:ok, join_path(root, resolved_segments ++ [segment | rest])}
+        {:error, :enoent} ->
+          {:ok, join_path(root, resolved_segments ++ [segment | rest])}
 
-      {:error, reason} ->
-        {:error, reason}
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 

--- a/elixir/lib/symphony_elixir/prompt_builder.ex
+++ b/elixir/lib/symphony_elixir/prompt_builder.ex
@@ -1,13 +1,13 @@
 defmodule SymphonyElixir.PromptBuilder do
   @moduledoc """
-  Builds agent prompts from Linear issue data.
+  Builds agent prompts from tracker issue data.
   """
 
   alias SymphonyElixir.{Config, Workflow}
 
   @render_opts [strict_variables: true, strict_filters: true]
 
-  @spec build_prompt(SymphonyElixir.Linear.Issue.t(), keyword()) :: String.t()
+  @spec build_prompt(SymphonyElixir.Tracker.Issue.t(), keyword()) :: String.t()
   def build_prompt(issue, opts \\ []) do
     template =
       Workflow.current()

--- a/elixir/lib/symphony_elixir/tracker.ex
+++ b/elixir/lib/symphony_elixir/tracker.ex
@@ -39,6 +39,7 @@ defmodule SymphonyElixir.Tracker do
   @spec adapter() :: module()
   def adapter do
     case Config.settings!().tracker.kind do
+      "github" -> SymphonyElixir.GitHub.Adapter
       "memory" -> SymphonyElixir.Tracker.Memory
       _ -> SymphonyElixir.Linear.Adapter
     end

--- a/elixir/lib/symphony_elixir/tracker/issue.ex
+++ b/elixir/lib/symphony_elixir/tracker/issue.ex
@@ -1,6 +1,6 @@
-defmodule SymphonyElixir.Linear.Issue do
+defmodule SymphonyElixir.Tracker.Issue do
   @moduledoc """
-  Normalized Linear issue representation used by the orchestrator.
+  Normalized issue representation used by tracker adapters and the orchestrator.
   """
 
   defstruct [
@@ -30,6 +30,7 @@ defmodule SymphonyElixir.Linear.Issue do
           branch_name: String.t() | nil,
           url: String.t() | nil,
           assignee_id: String.t() | nil,
+          blocked_by: [map()],
           labels: [String.t()],
           assigned_to_worker: boolean(),
           created_at: DateTime.t() | nil,

--- a/elixir/lib/symphony_elixir/tracker/memory.ex
+++ b/elixir/lib/symphony_elixir/tracker/memory.ex
@@ -5,7 +5,7 @@ defmodule SymphonyElixir.Tracker.Memory do
 
   @behaviour SymphonyElixir.Tracker
 
-  alias SymphonyElixir.Linear.Issue
+  alias SymphonyElixir.Tracker.Issue
 
   @spec fetch_candidate_issues() :: {:ok, [Issue.t()]} | {:error, term()}
   def fetch_candidate_issues do

--- a/elixir/test/mix/tasks/pr_body_check_test.exs
+++ b/elixir/test/mix/tasks/pr_body_check_test.exs
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails when template is missing" do
     in_temp_repo(fn ->
-      File.write!("body.md", @valid_body)
+      File.write!("body.md", valid_body())
 
       assert_raise Mix.Error, ~r/Unable to read PR template/, fn ->
         Check.run(["lint", "--file", "body.md"])
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
   test "fails when template has no headings" do
     in_temp_repo(fn ->
       write_template!("no headings here")
-      File.write!("body.md", @valid_body)
+      File.write!("body.md", valid_body())
 
       assert_raise Mix.Error, ~r/No markdown headings found/, fn ->
         Check.run(["lint", "--file", "body.md"])
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails when body file is missing" do
     in_temp_repo(fn ->
-      write_template!(@template)
+      write_template!(template())
 
       assert_raise Mix.Error, ~r/Unable to read missing\.md/, fn ->
         Check.run(["lint", "--file", "missing.md"])
@@ -104,8 +104,8 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails when body still has placeholders" do
     in_temp_repo(fn ->
-      write_template!(@template)
-      File.write!("body.md", @template)
+      write_template!(template())
+      File.write!("body.md", template())
 
       error_output =
         capture_io(:stderr, fn ->
@@ -120,9 +120,9 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails when heading is missing" do
     in_temp_repo(fn ->
-      write_template!(@template)
+      write_template!(template())
 
-      missing_heading = String.replace(@valid_body, "#### Alternatives\n\n- Alternative considered.\n\n", "")
+      missing_heading = String.replace(valid_body(), "#### Alternatives\n\n- Alternative considered.\n\n", "")
       File.write!("body.md", missing_heading)
 
       error_output =
@@ -138,7 +138,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails when headings are out of order" do
     in_temp_repo(fn ->
-      write_template!(@template)
+      write_template!(template())
 
       out_of_order = """
       #### TL;DR
@@ -177,9 +177,9 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails on empty section" do
     in_temp_repo(fn ->
-      write_template!(@template)
+      write_template!(template())
 
-      empty_context = String.replace(@valid_body, "Context text.", "")
+      empty_context = String.replace(valid_body(), "Context text.", "")
       File.write!("body.md", empty_context)
 
       error_output =
@@ -195,7 +195,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails when a middle section is blank before the next heading" do
     in_temp_repo(fn ->
-      write_template!(@template)
+      write_template!(template())
 
       blank_alternatives = """
       #### Context
@@ -233,7 +233,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails when bullet and checkbox expectations are not met" do
     in_temp_repo(fn ->
-      write_template!(@template)
+      write_template!(template())
 
       invalid_body = """
       #### Context
@@ -275,7 +275,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails when heading has no content delimiter" do
     in_temp_repo(fn ->
-      write_template!(@template)
+      write_template!(template())
       File.write!("body.md", "#### Context\nContext text.")
 
       capture_io(:stderr, fn ->
@@ -288,7 +288,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "fails when heading appears at end of file" do
     in_temp_repo(fn ->
-      write_template!(@template)
+      write_template!(template())
       File.write!("body.md", "#### Context")
 
       error_output =
@@ -304,8 +304,8 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   test "passes for valid body" do
     in_temp_repo(fn ->
-      write_template!(@template)
-      File.write!("body.md", @valid_body)
+      write_template!(template())
+      File.write!("body.md", valid_body())
 
       output =
         capture_io(fn ->
@@ -337,5 +337,12 @@ defmodule Mix.Tasks.PrBody.CheckTest do
   defp write_template!(content) do
     File.mkdir_p!(".github")
     File.write!(".github/pull_request_template.md", content)
+  end
+
+  defp template, do: normalize_line_endings(@template)
+  defp valid_body, do: normalize_line_endings(@valid_body)
+
+  defp normalize_line_endings(content) when is_binary(content) do
+    String.replace(content, "\r\n", "\n")
   end
 end

--- a/elixir/test/mix/tasks/workspace_before_remove_test.exs
+++ b/elixir/test/mix/tasks/workspace_before_remove_test.exs
@@ -305,12 +305,13 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       File.mkdir_p!(bin_dir)
       File.write!(log_path, "")
       original_path = System.get_env("PATH") || ""
-      path_with_binaries = Enum.join([bin_dir, original_path], ":")
+      path_with_binaries = path_join([bin_dir, original_path])
 
       Enum.each(scripts, fn {name, script} ->
         path = Path.join(bin_dir, name)
         File.write!(path, script)
         File.chmod!(path, 0o755)
+        maybe_write_windows_wrapper!(path)
       end)
 
       with_env(
@@ -328,8 +329,26 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
   end
 
   defp with_path(paths, fun) do
-    with_env(%{"PATH" => Enum.join(paths, ":")}, fun)
+    with_env(%{"PATH" => path_join(paths)}, fun)
   end
+
+  defp maybe_write_windows_wrapper!(script_path) do
+    if windows?() do
+      File.write!(script_path <> ".bat", """
+      @echo off
+      sh "%~dp0#{Path.basename(script_path)}" %*
+      exit /b %ERRORLEVEL%
+      """)
+    end
+  end
+
+  defp path_join(paths), do: Enum.join(paths, <<path_separator()::utf8>>)
+
+  defp path_separator do
+    if windows?(), do: ?;, else: ?:
+  end
+
+  defp windows?, do: match?({:win32, _}, :os.type())
 
   defp with_env(overrides, fun) do
     keys = Map.keys(overrides)

--- a/elixir/test/support/snapshot_support.exs
+++ b/elixir/test/support/snapshot_support.exs
@@ -34,7 +34,7 @@ defmodule SymphonyElixir.TestSupport.Snapshot do
     else
       case File.read(path) do
         {:ok, expected} ->
-          assert normalized == expected,
+          assert normalized == normalize_content(expected),
                  "Snapshot mismatch for `#{relative_path}`. #{@update_snapshot_hint}"
 
         {:error, :enoent} ->

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -12,7 +12,7 @@ defmodule SymphonyElixir.TestSupport do
       alias SymphonyElixir.Config
       alias SymphonyElixir.HttpServer
       alias SymphonyElixir.Linear.Client
-      alias SymphonyElixir.Linear.Issue
+      alias SymphonyElixir.Tracker.Issue
       alias SymphonyElixir.Orchestrator
       alias SymphonyElixir.PromptBuilder
       alias SymphonyElixir.StatusDashboard
@@ -96,6 +96,12 @@ defmodule SymphonyElixir.TestSupport do
           tracker_endpoint: "https://api.linear.app/graphql",
           tracker_api_token: "token",
           tracker_project_slug: "project",
+          tracker_owner: nil,
+          tracker_repo: nil,
+          tracker_project_owner: nil,
+          tracker_project_owner_type: nil,
+          tracker_project_number: nil,
+          tracker_project_status_field: nil,
           tracker_assignee: nil,
           tracker_active_states: ["Todo", "In Progress"],
           tracker_terminal_states: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"],
@@ -133,6 +139,12 @@ defmodule SymphonyElixir.TestSupport do
     tracker_endpoint = Keyword.get(config, :tracker_endpoint)
     tracker_api_token = Keyword.get(config, :tracker_api_token)
     tracker_project_slug = Keyword.get(config, :tracker_project_slug)
+    tracker_owner = Keyword.get(config, :tracker_owner)
+    tracker_repo = Keyword.get(config, :tracker_repo)
+    tracker_project_owner = Keyword.get(config, :tracker_project_owner)
+    tracker_project_owner_type = Keyword.get(config, :tracker_project_owner_type)
+    tracker_project_number = Keyword.get(config, :tracker_project_number)
+    tracker_project_status_field = Keyword.get(config, :tracker_project_status_field)
     tracker_assignee = Keyword.get(config, :tracker_assignee)
     tracker_active_states = Keyword.get(config, :tracker_active_states)
     tracker_terminal_states = Keyword.get(config, :tracker_terminal_states)
@@ -171,6 +183,12 @@ defmodule SymphonyElixir.TestSupport do
         "  endpoint: #{yaml_value(tracker_endpoint)}",
         "  api_key: #{yaml_value(tracker_api_token)}",
         "  project_slug: #{yaml_value(tracker_project_slug)}",
+        "  owner: #{yaml_value(tracker_owner)}",
+        "  repo: #{yaml_value(tracker_repo)}",
+        "  project_owner: #{yaml_value(tracker_project_owner)}",
+        "  project_owner_type: #{yaml_value(tracker_project_owner_type)}",
+        "  project_number: #{yaml_value(tracker_project_number)}",
+        "  project_status_field: #{yaml_value(tracker_project_status_field)}",
         "  assignee: #{yaml_value(tracker_assignee)}",
         "  active_states: #{yaml_value(tracker_active_states)}",
         "  terminal_states: #{yaml_value(tracker_terminal_states)}",

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -222,7 +222,12 @@ defmodule SymphonyElixir.TestSupport do
   end
 
   defp yaml_value(value) when is_binary(value) do
-    "\"" <> String.replace(value, "\"", "\\\"") <> "\""
+    escaped =
+      value
+      |> String.replace("\\", "\\\\")
+      |> String.replace("\"", "\\\"")
+
+    "\"" <> escaped <> "\""
   end
 
   defp yaml_value(value) when is_integer(value), do: to_string(value)

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -53,24 +53,25 @@ defmodule SymphonyElixir.AppServerTest do
 
       File.mkdir_p!(workspace_root)
       File.mkdir_p!(outside_workspace)
-      File.ln_s!(outside_workspace, symlink_workspace)
 
-      write_workflow_file!(Workflow.workflow_file_path(),
-        workspace_root: workspace_root
-      )
+      if create_symlink_or_skip?(outside_workspace, symlink_workspace) do
+        write_workflow_file!(Workflow.workflow_file_path(),
+          workspace_root: workspace_root
+        )
 
-      issue = %Issue{
-        id: "issue-workspace-symlink-guard",
-        identifier: "MT-1000",
-        title: "Validate symlink workspace guard",
-        description: "Ensure app-server refuses symlink escape cwd targets",
-        state: "In Progress",
-        url: "https://example.org/issues/MT-1000",
-        labels: ["backend"]
-      }
+        issue = %Issue{
+          id: "issue-workspace-symlink-guard",
+          identifier: "MT-1000",
+          title: "Validate symlink workspace guard",
+          description: "Ensure app-server refuses symlink escape cwd targets",
+          state: "In Progress",
+          url: "https://example.org/issues/MT-1000",
+          labels: ["backend"]
+        }
 
-      assert {:error, {:invalid_workspace_cwd, :symlink_escape, ^symlink_workspace, _root}} =
-               AppServer.run(symlink_workspace, "guard", issue)
+        assert {:error, {:invalid_workspace_cwd, :symlink_escape, ^symlink_workspace, _root}} =
+                 AppServer.run(symlink_workspace, "guard", issue)
+      end
     after
       File.rm_rf(test_root)
     end
@@ -1301,7 +1302,7 @@ defmodule SymphonyElixir.AppServerTest do
 
       File.mkdir_p!(test_root)
       System.put_env("SYMP_TEST_SSH_TRACE", trace_file)
-      System.put_env("PATH", test_root <> ":" <> (previous_path || ""))
+      System.put_env("PATH", path_join([test_root, previous_path || ""]))
 
       File.write!(fake_ssh, """
       #!/bin/sh
@@ -1335,6 +1336,7 @@ defmodule SymphonyElixir.AppServerTest do
       """)
 
       File.chmod!(fake_ssh, 0o755)
+      maybe_write_windows_wrapper!(fake_ssh)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: "/remote/workspaces",
@@ -1408,6 +1410,37 @@ defmodule SymphonyElixir.AppServerTest do
              end)
     after
       File.rm_rf(test_root)
+    end
+  end
+
+  defp maybe_write_windows_wrapper!(script_path) do
+    if windows?() do
+      File.write!(script_path <> ".bat", """
+      @echo off
+      sh "%~dp0#{Path.basename(script_path)}" %*
+      exit /b %ERRORLEVEL%
+      """)
+    end
+  end
+
+  defp path_join(paths), do: Enum.join(paths, <<path_separator()::utf8>>)
+
+  defp path_separator do
+    if windows?(), do: ?;, else: ?:
+  end
+
+  defp windows?, do: match?({:win32, _}, :os.type())
+
+  defp create_symlink_or_skip?(target, link) do
+    case File.ln_s(target, link) do
+      :ok ->
+        true
+
+      {:error, reason} when reason in [:eperm, :eacces] ->
+        false
+
+      {:error, reason} ->
+        flunk("failed to create symlink #{inspect(link)} -> #{inspect(target)}: #{inspect(reason)}")
     end
   end
 end

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -428,14 +428,17 @@ defmodule SymphonyElixir.AppServerTest do
 
                  payload["id"] == 2 and
                    case get_in(payload, ["params", "dynamicTools"]) do
-                     [
-                       %{
-                         "description" => description,
-                         "inputSchema" => %{"required" => ["query"]},
-                         "name" => "linear_graphql"
-                       }
-                     ] ->
-                       description =~ "Linear"
+                     tools when is_list(tools) ->
+                       tool_names = Enum.map(tools, & &1["name"])
+                       linear_tool = Enum.find(tools, &(&1["name"] == "linear_graphql"))
+
+                       "linear_graphql" in tool_names and
+                         "github_graphql" in tool_names and
+                         "sync_workpad" in tool_names and
+                         is_map(linear_tool) and
+                         get_in(linear_tool, ["inputSchema", "required"]) == ["query"] and
+                         is_binary(linear_tool["description"]) and
+                         linear_tool["description"] =~ "Linear"
 
                      _ ->
                        false

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -1290,7 +1290,7 @@ defmodule SymphonyElixir.CoreTest do
 
       File.mkdir_p!(test_root)
       System.put_env("SYMP_TEST_SSH_TRACE", trace_file)
-      System.put_env("PATH", test_root <> ":" <> (previous_path || ""))
+      System.put_env("PATH", path_join([test_root, previous_path || ""]))
 
       File.write!(fake_ssh, """
       #!/bin/sh
@@ -1298,11 +1298,11 @@ defmodule SymphonyElixir.CoreTest do
       printf 'ARGV:%s\\n' "$*" >> "$trace_file"
 
       case "$*" in
-        *worker-a*"__SYMPHONY_WORKSPACE__"*)
+        *worker-a*__SYMPHONY_WORKSPACE__*)
           printf '%s\\n' 'worker-a prepare failed' >&2
           exit 75
           ;;
-        *worker-b*"__SYMPHONY_WORKSPACE__"*)
+        *worker-b*__SYMPHONY_WORKSPACE__*)
           printf '%s\\t%s\\t%s\\n' '__SYMPHONY_WORKSPACE__' '1' '/remote/home/.symphony-remote-workspaces/MT-SSH-FAILOVER'
           exit 0
           ;;
@@ -1313,6 +1313,7 @@ defmodule SymphonyElixir.CoreTest do
       """)
 
       File.chmod!(fake_ssh, 0o755)
+      maybe_write_windows_wrapper!(fake_ssh)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: "~/.symphony-remote-workspaces",
@@ -1469,6 +1470,24 @@ defmodule SymphonyElixir.CoreTest do
       File.rm_rf(test_root)
     end
   end
+
+  defp maybe_write_windows_wrapper!(script_path) do
+    if windows?() do
+      File.write!(script_path <> ".bat", """
+      @echo off
+      sh "%~dp0#{Path.basename(script_path)}" %*
+      exit /b %ERRORLEVEL%
+      """)
+    end
+  end
+
+  defp path_join(paths), do: Enum.join(paths, <<path_separator()::utf8>>)
+
+  defp path_separator do
+    if windows?(), do: ?;, else: ?:
+  end
+
+  defp windows?, do: match?({:win32, _}, :os.type())
 
   test "agent runner stops continuing once agent.max_turns is reached" do
     test_root =

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -133,6 +133,111 @@ defmodule SymphonyElixir.CoreTest do
     assert :ok = Config.validate!()
   end
 
+  test "github tracker settings resolve from GITHUB_TOKEN env var" do
+    previous_github_token = System.get_env("GITHUB_TOKEN")
+    env_api_key = "test-github-api-key"
+
+    on_exit(fn -> restore_env("GITHUB_TOKEN", previous_github_token) end)
+    System.put_env("GITHUB_TOKEN", env_api_key)
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_endpoint: nil,
+      tracker_api_token: nil,
+      tracker_owner: "xuelongmu",
+      tracker_repo: "symphony",
+      tracker_project_owner: "xuelongmu",
+      tracker_project_number: 1,
+      codex_command: "/bin/sh app-server"
+    )
+
+    settings = Config.settings!()
+    assert settings.tracker.api_key == env_api_key
+    assert settings.tracker.endpoint == "https://api.github.com"
+    assert settings.tracker.owner == "xuelongmu"
+    assert settings.tracker.repo == "symphony"
+    assert settings.tracker.project_owner == "xuelongmu"
+    assert settings.tracker.project_owner_type == "user"
+    assert settings.tracker.project_number == 1
+    assert settings.tracker.project_status_field == "Status"
+    assert :ok = Config.validate!()
+    assert SymphonyElixir.Tracker.adapter() == SymphonyElixir.GitHub.Adapter
+  end
+
+  test "github tracker validation requires repo and project settings" do
+    previous_github_token = System.get_env("GITHUB_TOKEN")
+
+    on_exit(fn -> restore_env("GITHUB_TOKEN", previous_github_token) end)
+    System.delete_env("GITHUB_TOKEN")
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_api_token: nil,
+      tracker_owner: nil,
+      tracker_repo: nil,
+      tracker_project_owner: nil,
+      tracker_project_number: nil
+    )
+
+    assert {:error, :missing_github_api_token} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_api_token: "token",
+      tracker_owner: nil,
+      tracker_repo: "symphony",
+      tracker_project_owner: "xuelongmu",
+      tracker_project_number: 1
+    )
+
+    assert {:error, :missing_github_owner} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_api_token: "token",
+      tracker_owner: "xuelongmu",
+      tracker_repo: nil,
+      tracker_project_owner: "xuelongmu",
+      tracker_project_number: 1
+    )
+
+    assert {:error, :missing_github_repo} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_api_token: "token",
+      tracker_owner: "xuelongmu",
+      tracker_repo: "symphony",
+      tracker_project_owner: nil,
+      tracker_project_number: 1
+    )
+
+    assert {:error, :missing_github_project_owner} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_api_token: "token",
+      tracker_owner: "xuelongmu",
+      tracker_repo: "symphony",
+      tracker_project_owner: "xuelongmu",
+      tracker_project_owner_type: "team",
+      tracker_project_number: 1
+    )
+
+    assert {:error, {:unsupported_github_project_owner_type, "team"}} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_api_token: "token",
+      tracker_owner: "xuelongmu",
+      tracker_repo: "symphony",
+      tracker_project_owner: "xuelongmu",
+      tracker_project_number: nil
+    )
+
+    assert {:error, :missing_github_project_number} = Config.validate!()
+  end
+
   test "linear assignee resolves from LINEAR_ASSIGNEE env var" do
     previous_linear_assignee = System.get_env("LINEAR_ASSIGNEE")
     env_assignee = "dev@example.com"
@@ -883,7 +988,7 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue)
 
-    assert prompt =~ "You are working on a Linear issue."
+    assert prompt =~ "You are working on an issue from the configured tracker."
     assert prompt =~ "Identifier: MT-777"
     assert prompt =~ "Title: Make fallback prompt useful"
     assert prompt =~ "Body:"

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -519,8 +519,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
           end
         )
 
-      assert_received {:github_client_called, lookup_query,
-                       %{"owner" => "xuelongmu", "repo" => "symphony", "number" => 3}, []}
+      assert_received {:github_client_called, lookup_query, %{"owner" => "xuelongmu", "repo" => "symphony", "number" => 3}, []}
 
       assert lookup_query =~ "issue(number: $number)"
 

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -3,23 +3,32 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
 
   alias SymphonyElixir.Codex.DynamicTool
 
-  test "tool_specs advertises the linear_graphql input contract" do
-    assert [
-             %{
-               "description" => description,
-               "inputSchema" => %{
-                 "properties" => %{
-                   "query" => _,
-                   "variables" => _
-                 },
-                 "required" => ["query"],
-                 "type" => "object"
-               },
-               "name" => "linear_graphql"
-             }
-           ] = DynamicTool.tool_specs()
+  test "tool_specs advertises dynamic tool input contracts" do
+    specs = DynamicTool.tool_specs()
 
-    assert description =~ "Linear"
+    assert Enum.map(specs, & &1["name"]) == [
+             "linear_graphql",
+             "github_graphql",
+             "sync_workpad"
+           ]
+
+    linear_spec = Enum.find(specs, &(&1["name"] == "linear_graphql"))
+    github_spec = Enum.find(specs, &(&1["name"] == "github_graphql"))
+    sync_spec = Enum.find(specs, &(&1["name"] == "sync_workpad"))
+
+    assert linear_spec["description"] =~ "Linear"
+    assert linear_spec["inputSchema"]["required"] == ["query"]
+    assert Map.has_key?(linear_spec["inputSchema"]["properties"], "variables")
+
+    assert github_spec["description"] =~ "GitHub"
+    assert github_spec["inputSchema"]["required"] == ["query"]
+    assert Map.has_key?(github_spec["inputSchema"]["properties"], "variables")
+
+    assert sync_spec["description"] =~ "workpad"
+    assert sync_spec["inputSchema"]["additionalProperties"] == false
+    assert sync_spec["inputSchema"]["required"] == ["file_path"]
+    assert Map.has_key?(sync_spec["inputSchema"]["properties"], "issue_number")
+    assert Map.has_key?(sync_spec["inputSchema"]["properties"], "issue_id")
   end
 
   test "unsupported tools return a failure payload with the supported tool list" do
@@ -30,7 +39,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     assert Jason.decode!(response["output"]) == %{
              "error" => %{
                "message" => ~s(Unsupported dynamic tool: "not_a_real_tool".),
-               "supportedTools" => ["linear_graphql"]
+               "supportedTools" => ["linear_graphql", "github_graphql", "sync_workpad"]
              }
            }
 
@@ -306,5 +315,417 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
 
     assert response["success"] == true
     assert response["output"] == ":ok"
+  end
+
+  test "github_graphql returns successful GraphQL responses as tool text" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "github_graphql",
+        %{
+          "query" => "query Repo($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { id } }",
+          "variables" => %{"owner" => "xuelongmu", "name" => "symphony"}
+        },
+        github_client: fn query, variables, opts ->
+          send(test_pid, {:github_client_called, query, variables, opts})
+          {:ok, %{"data" => %{"repository" => %{"id" => "repo_node_1"}}}}
+        end
+      )
+
+    assert_received {:github_client_called, _query, %{"owner" => "xuelongmu", "name" => "symphony"}, []}
+
+    assert response["success"] == true
+    assert Jason.decode!(response["output"]) == %{"data" => %{"repository" => %{"id" => "repo_node_1"}}}
+    assert response["contentItems"] == [%{"type" => "inputText", "text" => response["output"]}]
+  end
+
+  test "github_graphql validates arguments before calling GitHub" do
+    response =
+      DynamicTool.execute(
+        "github_graphql",
+        %{"variables" => %{}},
+        github_client: fn _query, _variables, _opts ->
+          flunk("github client should not be called when arguments are invalid")
+        end
+      )
+
+    assert response["success"] == false
+
+    assert Jason.decode!(response["output"]) == %{
+             "error" => %{
+               "message" => "`github_graphql` requires a non-empty `query` string."
+             }
+           }
+
+    invalid_variables =
+      DynamicTool.execute(
+        "github_graphql",
+        %{"query" => "query Viewer { viewer { login } }", "variables" => ["bad"]},
+        github_client: fn _query, _variables, _opts ->
+          flunk("github client should not be called when variables are invalid")
+        end
+      )
+
+    assert invalid_variables["success"] == false
+
+    assert Jason.decode!(invalid_variables["output"]) == %{
+             "error" => %{
+               "message" => "`github_graphql.variables` must be a JSON object when provided."
+             }
+           }
+  end
+
+  test "github_graphql marks GraphQL errors as failures while preserving the body" do
+    response =
+      DynamicTool.execute(
+        "github_graphql",
+        %{"query" => "query Bad { nope }"},
+        github_client: fn _query, _variables, _opts ->
+          {:ok, %{"errors" => [%{"message" => "Field 'nope' does not exist"}], "data" => nil}}
+        end
+      )
+
+    assert response["success"] == false
+
+    assert Jason.decode!(response["output"]) == %{
+             "data" => nil,
+             "errors" => [%{"message" => "Field 'nope' does not exist"}]
+           }
+
+    wrapped_errors =
+      DynamicTool.execute(
+        "github_graphql",
+        %{"query" => "query Bad { nope }"},
+        github_client: fn _query, _variables, _opts ->
+          {:error, {:github_graphql_errors, [%{"message" => "Field 'nope' does not exist"}]}}
+        end
+      )
+
+    assert wrapped_errors["success"] == false
+    assert Jason.decode!(wrapped_errors["output"]) == %{"errors" => [%{"message" => "Field 'nope' does not exist"}]}
+  end
+
+  test "github_graphql formats transport and auth failures" do
+    missing_token =
+      DynamicTool.execute(
+        "github_graphql",
+        %{"query" => "query Viewer { viewer { login } }"},
+        github_client: fn _query, _variables, _opts -> {:error, :missing_github_api_token} end
+      )
+
+    assert missing_token["success"] == false
+
+    assert Jason.decode!(missing_token["output"]) == %{
+             "error" => %{
+               "message" => "Symphony is missing GitHub auth. Set `tracker.api_key` in `WORKFLOW.md` or export `GITHUB_TOKEN`."
+             }
+           }
+
+    wrapped_missing_token =
+      DynamicTool.execute(
+        "github_graphql",
+        %{"query" => "query Viewer { viewer { login } }"},
+        github_client: fn _query, _variables, _opts -> {:error, {:github_graphql_request, :missing_github_api_token}} end
+      )
+
+    assert Jason.decode!(wrapped_missing_token["output"]) == %{
+             "error" => %{
+               "message" => "Symphony is missing GitHub auth. Set `tracker.api_key` in `WORKFLOW.md` or export `GITHUB_TOKEN`."
+             }
+           }
+
+    wrong_tracker =
+      DynamicTool.execute(
+        "github_graphql",
+        %{"query" => "query Viewer { viewer { login } }"},
+        github_client: fn _query, _variables, _opts -> {:error, :github_tracker_not_configured} end
+      )
+
+    assert Jason.decode!(wrong_tracker["output"]) == %{
+             "error" => %{
+               "message" => "`github_graphql` is available only when `tracker.kind` is `github`."
+             }
+           }
+
+    status_error =
+      DynamicTool.execute(
+        "github_graphql",
+        %{"query" => "query Viewer { viewer { login } }"},
+        github_client: fn _query, _variables, _opts -> {:error, {:github_graphql_status, 502, "bad gateway"}} end
+      )
+
+    assert Jason.decode!(status_error["output"]) == %{
+             "error" => %{
+               "message" => "GitHub GraphQL request failed with HTTP 502.",
+               "status" => 502,
+               "body" => "bad gateway"
+             }
+           }
+
+    request_error =
+      DynamicTool.execute(
+        "github_graphql",
+        %{"query" => "query Viewer { viewer { login } }"},
+        github_client: fn _query, _variables, _opts -> {:error, {:github_api_request, :timeout}} end
+      )
+
+    assert Jason.decode!(request_error["output"]) == %{
+             "error" => %{
+               "message" => "GitHub GraphQL request failed before receiving a successful response.",
+               "reason" => ":timeout"
+             }
+           }
+  end
+
+  test "sync_workpad creates a GitHub issue comment from a workspace-relative file" do
+    root = tmp_root()
+    body = "## Codex Workpad\n\n- [ ] Plan"
+    write_workpad!(root, "notes/workpad.md", body)
+    test_pid = self()
+
+    try do
+      response =
+        DynamicTool.execute(
+          "sync_workpad",
+          %{
+            "tracker" => "github",
+            "issue_number" => 3,
+            "owner" => "xuelongmu",
+            "repo" => "symphony",
+            "file_path" => "notes/workpad.md"
+          },
+          workspace: root,
+          github_client: fn query, variables, opts ->
+            send(test_pid, {:github_client_called, query, variables, opts})
+
+            cond do
+              query =~ "SymphonyGitHubIssueNode" ->
+                {:ok, %{"data" => %{"repository" => %{"issue" => %{"id" => "ISSUE_node_3"}}}}}
+
+              query =~ "addComment" ->
+                {:ok,
+                 %{
+                   "data" => %{
+                     "addComment" => %{
+                       "commentEdge" => %{"node" => %{"id" => "IC_node_1", "url" => "https://github.test/comment"}}
+                     }
+                   }
+                 }}
+
+              true ->
+                flunk("unexpected GitHub query: #{query}")
+            end
+          end
+        )
+
+      assert_received {:github_client_called, lookup_query,
+                       %{"owner" => "xuelongmu", "repo" => "symphony", "number" => 3}, []}
+
+      assert lookup_query =~ "issue(number: $number)"
+
+      assert_received {:github_client_called, create_query, %{"subjectId" => "ISSUE_node_3", "body" => ^body}, []}
+      assert create_query =~ "addComment"
+
+      assert response["success"] == true
+      assert get_in(Jason.decode!(response["output"]), ["data", "addComment", "commentEdge", "node", "id"]) == "IC_node_1"
+    after
+      File.rm_rf(root)
+    end
+  end
+
+  test "sync_workpad updates a GitHub issue comment from an explicit absolute file path" do
+    root = tmp_root()
+    body = "Updated GitHub workpad."
+    path = write_workpad!(root, "workpad.md", body)
+    test_pid = self()
+
+    try do
+      response =
+        DynamicTool.execute(
+          "sync_workpad",
+          %{
+            "tracker" => "github",
+            "issue_number" => "3",
+            "comment_id" => "IC_node_1",
+            "file_path" => path
+          },
+          github_client: fn query, variables, opts ->
+            send(test_pid, {:github_client_called, query, variables, opts})
+            {:ok, %{"data" => %{"updateIssueComment" => %{"issueComment" => %{"id" => "IC_node_1"}}}}}
+          end
+        )
+
+      assert_received {:github_client_called, query, %{"id" => "IC_node_1", "body" => ^body}, []}
+      assert query =~ "updateIssueComment"
+      assert response["success"] == true
+    after
+      File.rm_rf(root)
+    end
+  end
+
+  test "sync_workpad preserves Linear create and update behavior" do
+    root = tmp_root()
+    create_body = "Linear workpad."
+    update_body = "Updated Linear workpad."
+    create_path = write_workpad!(root, "create.md", create_body)
+    update_path = write_workpad!(root, "update.md", update_body)
+    test_pid = self()
+
+    try do
+      create_response =
+        DynamicTool.execute(
+          "sync_workpad",
+          %{"issue_id" => "ENG-42", "file_path" => create_path},
+          linear_client: fn query, variables, opts ->
+            send(test_pid, {:linear_client_called, query, variables, opts})
+            {:ok, %{"data" => %{"commentCreate" => %{"success" => true, "comment" => %{"id" => "c1"}}}}}
+          end
+        )
+
+      assert_received {:linear_client_called, create_query, %{"issueId" => "ENG-42", "body" => ^create_body}, []}
+      assert create_query =~ "commentCreate"
+      assert create_response["success"] == true
+
+      update_response =
+        DynamicTool.execute(
+          "sync_workpad",
+          %{"tracker" => "linear", "issue_id" => "ENG-42", "comment_id" => "c1", "file_path" => update_path},
+          linear_client: fn query, variables, opts ->
+            send(test_pid, {:linear_client_called, query, variables, opts})
+            {:ok, %{"data" => %{"commentUpdate" => %{"success" => true, "comment" => %{"id" => "c1"}}}}}
+          end
+        )
+
+      assert_received {:linear_client_called, update_query, %{"id" => "c1", "body" => ^update_body}, []}
+      assert update_query =~ "commentUpdate"
+      assert update_response["success"] == true
+    after
+      File.rm_rf(root)
+    end
+  end
+
+  test "sync_workpad validates arguments before reading files or calling clients" do
+    response =
+      DynamicTool.execute(
+        "sync_workpad",
+        %{"issue_number" => 3, "file_path" => "workpad.md", "extra" => true},
+        github_client: fn _query, _variables, _opts ->
+          flunk("github client should not be called when arguments are invalid")
+        end
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "unsupported argument"
+
+    missing_issue =
+      DynamicTool.execute(
+        "sync_workpad",
+        %{"tracker" => "github", "file_path" => "workpad.md"},
+        github_client: fn _query, _variables, _opts ->
+          flunk("github client should not be called when the issue number is missing")
+        end
+      )
+
+    assert missing_issue["success"] == false
+    assert Jason.decode!(missing_issue["output"])["error"]["message"] =~ "issue_number"
+
+    invalid_linear =
+      DynamicTool.execute(
+        "sync_workpad",
+        %{"tracker" => "linear", "issue_id" => "ENG-42", "issue_number" => 3, "file_path" => "workpad.md"},
+        linear_client: fn _query, _variables, _opts ->
+          flunk("linear client should not be called when GitHub-only arguments are present")
+        end
+      )
+
+    assert invalid_linear["success"] == false
+    assert Jason.decode!(invalid_linear["output"])["error"]["message"] =~ "issue_number"
+  end
+
+  test "sync_workpad constrains file reads to the active workspace when provided" do
+    root = tmp_root()
+    outside_root = tmp_root()
+    outside_path = write_workpad!(outside_root, "outside.md", "outside")
+
+    try do
+      response =
+        DynamicTool.execute(
+          "sync_workpad",
+          %{
+            "tracker" => "github",
+            "issue_number" => 3,
+            "comment_id" => "IC_node_1",
+            "file_path" => outside_path
+          },
+          workspace: root,
+          github_client: fn _query, _variables, _opts ->
+            flunk("github client should not be called when file_path escapes the workspace")
+          end
+        )
+
+      assert response["success"] == false
+      assert Jason.decode!(response["output"])["error"]["message"] =~ "active workspace"
+    after
+      File.rm_rf(root)
+      File.rm_rf(outside_root)
+    end
+  end
+
+  test "sync_workpad requires absolute file paths when no workspace is configured" do
+    response =
+      DynamicTool.execute(
+        "sync_workpad",
+        %{
+          "tracker" => "github",
+          "issue_number" => 3,
+          "comment_id" => "IC_node_1",
+          "file_path" => "workpad.md"
+        },
+        github_client: fn _query, _variables, _opts ->
+          flunk("github client should not be called for relative paths without a workspace")
+        end
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "must be absolute"
+  end
+
+  test "sync_workpad rejects empty workpad files" do
+    root = tmp_root()
+    write_workpad!(root, "empty.md", "")
+
+    try do
+      response =
+        DynamicTool.execute(
+          "sync_workpad",
+          %{
+            "tracker" => "github",
+            "issue_number" => 3,
+            "comment_id" => "IC_node_1",
+            "file_path" => "empty.md"
+          },
+          workspace: root,
+          github_client: fn _query, _variables, _opts ->
+            flunk("github client should not be called for empty workpad files")
+          end
+        )
+
+      assert response["success"] == false
+      assert Jason.decode!(response["output"])["error"]["message"] =~ "file is empty"
+    after
+      File.rm_rf(root)
+    end
+  end
+
+  defp tmp_root do
+    Path.join(System.tmp_dir!(), "dynamic_tool_test_#{:erlang.unique_integer([:positive])}")
+  end
+
+  defp write_workpad!(root, relative_path, body) do
+    path = Path.join(root, relative_path)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, body)
+    path
   end
 end

--- a/elixir/test/symphony_elixir/github_adapter_test.exs
+++ b/elixir/test/symphony_elixir/github_adapter_test.exs
@@ -1,0 +1,123 @@
+defmodule SymphonyElixir.GitHubAdapterTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.GitHub.Adapter
+
+  defmodule FakeGitHubClient do
+    def fetch_candidate_issues do
+      send(self(), :fetch_candidate_issues_called)
+      {:ok, [:candidate]}
+    end
+
+    def fetch_issues_by_states(states) do
+      send(self(), {:fetch_issues_by_states_called, states})
+      {:ok, states}
+    end
+
+    def fetch_issue_states_by_ids(issue_ids) do
+      send(self(), {:fetch_issue_states_by_ids_called, issue_ids})
+      {:ok, issue_ids}
+    end
+
+    def create_comment(issue_id, body) do
+      send(self(), {:create_comment_called, issue_id, body})
+      Process.get({__MODULE__, :create_comment_result}, :ok)
+    end
+
+    def resolve_status_update(issue_id, state_name) do
+      send(self(), {:resolve_status_update_called, issue_id, state_name})
+
+      Process.get(
+        {__MODULE__, :resolve_status_update_result},
+        {:ok,
+         %{
+           project_id: "project-1",
+           item_id: "item-1",
+           field_id: "field-status",
+           option_id: "option-done",
+           state_name: state_name
+         }}
+      )
+    end
+
+    def update_project_item_status(status_update) do
+      send(self(), {:update_project_item_status_called, status_update})
+      Process.get({__MODULE__, :update_project_item_status_result}, :ok)
+    end
+
+    def patch_issue_state(issue_id, state_name) do
+      send(self(), {:patch_issue_state_called, issue_id, state_name})
+      Process.get({__MODULE__, :patch_issue_state_result}, :ok)
+    end
+  end
+
+  setup do
+    previous_client_module = Application.get_env(:symphony_elixir, :github_client_module)
+    Application.put_env(:symphony_elixir, :github_client_module, FakeGitHubClient)
+
+    on_exit(fn ->
+      if is_nil(previous_client_module) do
+        Application.delete_env(:symphony_elixir, :github_client_module)
+      else
+        Application.put_env(:symphony_elixir, :github_client_module, previous_client_module)
+      end
+    end)
+
+    :ok
+  end
+
+  test "delegates reads and comment creation to configured GitHub client" do
+    assert {:ok, [:candidate]} = Adapter.fetch_candidate_issues()
+    assert_receive :fetch_candidate_issues_called
+
+    assert {:ok, ["Todo"]} = Adapter.fetch_issues_by_states(["Todo"])
+    assert_receive {:fetch_issues_by_states_called, ["Todo"]}
+
+    assert {:ok, ["12"]} = Adapter.fetch_issue_states_by_ids(["12"])
+    assert_receive {:fetch_issue_states_by_ids_called, ["12"]}
+
+    assert :ok = Adapter.create_comment("12", "hello")
+    assert_receive {:create_comment_called, "12", "hello"}
+
+    Process.put({FakeGitHubClient, :create_comment_result}, {:error, :boom})
+    assert {:error, :boom} = Adapter.create_comment("12", "hello")
+  end
+
+  test "updates project status then patches GitHub issue state" do
+    assert :ok = Adapter.update_issue_state("12", "Done")
+
+    assert_receive {:resolve_status_update_called, "12", "Done"}
+
+    assert_receive {:update_project_item_status_called,
+                    %{
+                      project_id: "project-1",
+                      item_id: "item-1",
+                      field_id: "field-status",
+                      option_id: "option-done",
+                      state_name: "Done"
+                    }}
+
+    assert_receive {:patch_issue_state_called, "12", "Done"}
+  end
+
+  test "update_issue_state returns the first GitHub client error" do
+    Process.put({FakeGitHubClient, :resolve_status_update_result}, {:error, :state_missing})
+    assert {:error, :state_missing} = Adapter.update_issue_state("12", "Missing")
+    assert_receive {:resolve_status_update_called, "12", "Missing"}
+    refute_receive {:update_project_item_status_called, _}
+
+    Process.delete({FakeGitHubClient, :resolve_status_update_result})
+    Process.put({FakeGitHubClient, :update_project_item_status_result}, {:error, :update_failed})
+    assert {:error, :update_failed} = Adapter.update_issue_state("12", "Done")
+    assert_receive {:update_project_item_status_called, _}
+    refute_receive {:patch_issue_state_called, "12", "Done"}
+
+    Process.delete({FakeGitHubClient, :update_project_item_status_result})
+    Process.put({FakeGitHubClient, :patch_issue_state_result}, {:error, :patch_failed})
+    assert {:error, :patch_failed} = Adapter.update_issue_state("12", "Done")
+    assert_receive {:patch_issue_state_called, "12", "Done"}
+
+    Process.put({FakeGitHubClient, :resolve_status_update_result}, :unexpected)
+    assert {:error, :github_issue_update_failed} = Adapter.update_issue_state("12", "Done")
+  end
+end

--- a/elixir/test/symphony_elixir/github_client_test.exs
+++ b/elixir/test/symphony_elixir/github_client_test.exs
@@ -249,21 +249,18 @@ defmodule SymphonyElixir.GitHubClientTest do
 
     assert :ok = GitHubClient.create_comment_for_test("#12", "hello", request_fun)
 
-    assert_receive {:github_request, :post, "/repos/xuelongmu/symphony/issues/12/comments", headers,
-                    %{"body" => "hello"}, []}
+    assert_receive {:github_request, :post, "/repos/xuelongmu/symphony/issues/12/comments", headers, %{"body" => "hello"}, []}
 
     assert {"Authorization", "Bearer github-token"} in headers
     assert {"X-GitHub-Api-Version", "2026-03-10"} in headers
 
     assert :ok = GitHubClient.patch_issue_state_for_test("12", "Done", request_fun)
 
-    assert_receive {:github_request, :patch, "/repos/xuelongmu/symphony/issues/12", _headers,
-                    %{"state" => "closed", "state_reason" => "completed"}, []}
+    assert_receive {:github_request, :patch, "/repos/xuelongmu/symphony/issues/12", _headers, %{"state" => "closed", "state_reason" => "completed"}, []}
 
     assert :ok = GitHubClient.patch_issue_state_for_test("12", "Todo", request_fun)
 
-    assert_receive {:github_request, :patch, "/repos/xuelongmu/symphony/issues/12", _headers,
-                    %{"state" => "open", "state_reason" => "reopened"}, []}
+    assert_receive {:github_request, :patch, "/repos/xuelongmu/symphony/issues/12", _headers, %{"state" => "open", "state_reason" => "reopened"}, []}
   end
 
   test "REST request failures include GitHub-specific status tuples" do

--- a/elixir/test/symphony_elixir/github_client_test.exs
+++ b/elixir/test/symphony_elixir/github_client_test.exs
@@ -81,7 +81,8 @@ defmodule SymphonyElixir.GitHubClientTest do
     assert {:ok, issues} = GitHubClient.fetch_candidate_issues_for_test(graphql_fun)
 
     assert Enum.map(issues, & &1.id) == ["1", "4"]
-    assert Enum.map(issues, & &1.identifier) == ["xuelongmu/symphony#1", "xuelongmu/symphony#4"]
+    assert Enum.map(issues, & &1.identifier) == ["github-xuelongmu-symphony-1", "github-xuelongmu-symphony-4"]
+    refute Enum.any?(issues, &String.contains?(&1.identifier, ["/", "#", "?"]))
     assert Enum.map(issues, & &1.state) == ["Todo", "In Progress"]
 
     first_issue = hd(issues)
@@ -277,6 +278,25 @@ defmodule SymphonyElixir.GitHubClientTest do
              GitHubClient.patch_issue_state_for_test("12", "Done", request_fun)
 
     assert body =~ "Validation Failed"
+  end
+
+  test "REST URLs are built from GraphQL-suffixed endpoints by stripping the GraphQL path" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_endpoint: "https://api.github.test/graphql/",
+      tracker_api_token: "github-token",
+      tracker_owner: "xuelongmu",
+      tracker_repo: "symphony",
+      tracker_project_owner: "xuelongmu",
+      tracker_project_owner_type: "user",
+      tracker_project_number: 1,
+      tracker_project_status_field: "Status",
+      tracker_active_states: ["Todo", "In Progress"],
+      tracker_terminal_states: ["Closed", "Done"]
+    )
+
+    assert GitHubClient.github_rest_url_for_test("/repos/xuelongmu/symphony/issues/12") ==
+             "https://api.github.test/repos/xuelongmu/symphony/issues/12"
   end
 
   defp project_items_response(items, opts) do

--- a/elixir/test/symphony_elixir/github_client_test.exs
+++ b/elixir/test/symphony_elixir/github_client_test.exs
@@ -1,0 +1,370 @@
+defmodule SymphonyElixir.GitHubClientTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.GitHub.Client, as: GitHubClient
+
+  setup do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "github",
+      tracker_endpoint: "https://api.github.test",
+      tracker_api_token: "github-token",
+      tracker_owner: "xuelongmu",
+      tracker_repo: "symphony",
+      tracker_project_owner: "xuelongmu",
+      tracker_project_owner_type: "user",
+      tracker_project_number: 1,
+      tracker_project_status_field: "Status",
+      tracker_active_states: ["Todo", "In Progress"],
+      tracker_terminal_states: ["Closed", "Done"]
+    )
+
+    :ok
+  end
+
+  test "fetches candidate issues from paginated project items and excludes pull requests" do
+    graphql_fun = fn query, variables ->
+      send(self(), {:project_items_query, query, variables})
+
+      case variables.after do
+        nil ->
+          {:ok,
+           project_items_response(
+             [
+               project_issue_item(%{
+                 item_id: "item-1",
+                 number: 1,
+                 title: "Open todo",
+                 status: "Todo",
+                 state: "OPEN",
+                 labels: ["Backend"],
+                 assignees: ["alice"]
+               }),
+               project_pull_request_item(%{item_id: "item-pr", number: 2, status: "Todo"}),
+               project_issue_item(%{
+                 item_id: "item-3",
+                 number: 3,
+                 title: "Closed but stale",
+                 status: "Todo",
+                 state: "CLOSED"
+               })
+             ],
+             has_next_page: true,
+             end_cursor: "cursor-1"
+           )}
+
+        "cursor-1" ->
+          {:ok,
+           project_items_response(
+             [
+               project_issue_item(%{
+                 item_id: "item-4",
+                 number: 4,
+                 title: "Second page",
+                 status: "In Progress",
+                 state: "OPEN"
+               }),
+               project_issue_item(%{
+                 item_id: "item-other-repo",
+                 number: 5,
+                 title: "Other repo",
+                 status: "Todo",
+                 state: "OPEN",
+                 repo: "elsewhere"
+               })
+             ],
+             has_next_page: false,
+             end_cursor: nil
+           )}
+      end
+    end
+
+    assert {:ok, issues} = GitHubClient.fetch_candidate_issues_for_test(graphql_fun)
+
+    assert Enum.map(issues, & &1.id) == ["1", "4"]
+    assert Enum.map(issues, & &1.identifier) == ["xuelongmu/symphony#1", "xuelongmu/symphony#4"]
+    assert Enum.map(issues, & &1.state) == ["Todo", "In Progress"]
+
+    first_issue = hd(issues)
+    assert first_issue.labels == ["backend"]
+    assert first_issue.assignee_id == "alice"
+    assert first_issue.url == "https://github.com/xuelongmu/symphony/issues/1"
+    assert first_issue.created_at == ~U[2026-01-01 00:00:00Z]
+    assert first_issue.updated_at == ~U[2026-01-02 00:00:00Z]
+
+    assert_receive {:project_items_query, query, %{after: nil, first: 50, statusFieldName: "Status"}}
+    assert query =~ "SymphonyGitHubProjectItems"
+    assert_receive {:project_items_query, ^query, %{after: "cursor-1", first: 50, statusFieldName: "Status"}}
+  end
+
+  test "closed issues are returned as Closed for terminal-state fetch even when project status is stale" do
+    graphql_fun = fn _query, _variables ->
+      {:ok,
+       project_items_response(
+         [
+           project_issue_item(%{
+             item_id: "item-1",
+             number: 1,
+             title: "Open todo",
+             status: "Todo",
+             state: "OPEN"
+           }),
+           project_issue_item(%{
+             item_id: "item-2",
+             number: 2,
+             title: "Closed stale status",
+             status: "Todo",
+             state: "CLOSED"
+           })
+         ],
+         has_next_page: false,
+         end_cursor: nil
+       )}
+    end
+
+    assert {:ok, [%Issue{id: "2", state: "Closed"}]} =
+             GitHubClient.fetch_issues_by_states_for_test(["Closed"], graphql_fun)
+  end
+
+  test "fetch_issue_states_by_ids preserves requested id ordering" do
+    graphql_fun = fn _query, _variables ->
+      {:ok,
+       project_items_response(
+         [
+           project_issue_item(%{
+             item_id: "item-1",
+             number: 1,
+             title: "First",
+             status: "Todo",
+             state: "OPEN"
+           }),
+           project_issue_item(%{
+             item_id: "item-4",
+             number: 4,
+             title: "Fourth",
+             status: "In Progress",
+             state: "OPEN"
+           })
+         ],
+         has_next_page: false,
+         end_cursor: nil
+       )}
+    end
+
+    assert {:ok, issues} = GitHubClient.fetch_issue_states_by_ids_for_test(["4", "1", "missing"], graphql_fun)
+    assert Enum.map(issues, & &1.id) == ["4", "1"]
+  end
+
+  test "resolves project status field option and project item ids for updates" do
+    graphql_fun = fn query, variables ->
+      cond do
+        query =~ "SymphonyGitHubProjectFields" ->
+          send(self(), {:project_fields_query, variables})
+
+          {:ok,
+           project_fields_response([
+             %{"id" => "field-priority", "name" => "Priority", "dataType" => "SINGLE_SELECT", "options" => []},
+             %{
+               "id" => "field-status",
+               "name" => "Status",
+               "dataType" => "SINGLE_SELECT",
+               "options" => [
+                 %{"id" => "option-todo", "name" => "Todo"},
+                 %{"id" => "option-done", "name" => "Done"}
+               ]
+             }
+           ])}
+
+        query =~ "SymphonyGitHubProjectItems" ->
+          send(self(), {:project_items_query, variables})
+
+          {:ok,
+           project_items_response(
+             [
+               project_issue_item(%{
+                 item_id: "item-other-repo",
+                 number: 12,
+                 title: "Other repo same number",
+                 status: "Todo",
+                 state: "OPEN",
+                 repo: "elsewhere"
+               }),
+               project_issue_item(%{
+                 item_id: "item-12",
+                 number: 12,
+                 title: "Done issue",
+                 status: "Todo",
+                 state: "OPEN"
+               })
+             ],
+             has_next_page: false,
+             end_cursor: nil
+           )}
+      end
+    end
+
+    assert {:ok,
+            %{
+              project_id: "project-1",
+              item_id: "item-12",
+              field_id: "field-status",
+              option_id: "option-done",
+              state_name: "Done"
+            }} = GitHubClient.resolve_status_update_for_test("12", "Done", graphql_fun)
+
+    assert_receive {:project_fields_query, %{after: nil, first: 50, number: 1, owner: "xuelongmu"}}
+    assert_receive {:project_items_query, %{after: nil, first: 50, number: 1, owner: "xuelongmu"}}
+  end
+
+  test "returns GitHub-specific errors for missing status options and invalid issue ids" do
+    graphql_fun = fn query, _variables ->
+      cond do
+        query =~ "SymphonyGitHubProjectFields" ->
+          {:ok,
+           project_fields_response([
+             %{
+               "id" => "field-status",
+               "name" => "Status",
+               "dataType" => "SINGLE_SELECT",
+               "options" => [%{"id" => "option-todo", "name" => "Todo"}]
+             }
+           ])}
+
+        query =~ "SymphonyGitHubProjectItems" ->
+          {:ok, project_items_response([], has_next_page: false, end_cursor: nil)}
+      end
+    end
+
+    assert {:error, {:github_project_status_option_not_found, "Status", "Done"}} =
+             GitHubClient.resolve_status_update_for_test("12", "Done", graphql_fun)
+
+    assert {:error, {:invalid_github_issue_number, "not-a-number"}} =
+             GitHubClient.resolve_status_update_for_test("not-a-number", "Done", graphql_fun)
+  end
+
+  test "creates comments and patches issue state through REST request seam" do
+    request_fun = fn method, path, headers, json, params ->
+      send(self(), {:github_request, method, path, headers, json, params})
+      {:ok, %{status: if(method == :post, do: 201, else: 200), body: %{}}}
+    end
+
+    assert :ok = GitHubClient.create_comment_for_test("#12", "hello", request_fun)
+
+    assert_receive {:github_request, :post, "/repos/xuelongmu/symphony/issues/12/comments", headers,
+                    %{"body" => "hello"}, []}
+
+    assert {"Authorization", "Bearer github-token"} in headers
+    assert {"X-GitHub-Api-Version", "2026-03-10"} in headers
+
+    assert :ok = GitHubClient.patch_issue_state_for_test("12", "Done", request_fun)
+
+    assert_receive {:github_request, :patch, "/repos/xuelongmu/symphony/issues/12", _headers,
+                    %{"state" => "closed", "state_reason" => "completed"}, []}
+
+    assert :ok = GitHubClient.patch_issue_state_for_test("12", "Todo", request_fun)
+
+    assert_receive {:github_request, :patch, "/repos/xuelongmu/symphony/issues/12", _headers,
+                    %{"state" => "open", "state_reason" => "reopened"}, []}
+  end
+
+  test "REST request failures include GitHub-specific status tuples" do
+    request_fun = fn _method, _path, _headers, _json, _params ->
+      {:ok, %{status: 422, body: %{"message" => "Validation Failed"}}}
+    end
+
+    assert {:error, {:github_comment_create_status, 422, body}} =
+             GitHubClient.create_comment_for_test("12", "hello", request_fun)
+
+    assert body =~ "Validation Failed"
+
+    assert {:error, {:github_issue_patch_status, 422, body}} =
+             GitHubClient.patch_issue_state_for_test("12", "Done", request_fun)
+
+    assert body =~ "Validation Failed"
+  end
+
+  defp project_items_response(items, opts) do
+    %{
+      "data" => %{
+        "user" => %{
+          "projectV2" => %{
+            "id" => "project-1",
+            "items" => %{
+              "nodes" => items,
+              "pageInfo" => %{
+                "hasNextPage" => Keyword.fetch!(opts, :has_next_page),
+                "endCursor" => Keyword.fetch!(opts, :end_cursor)
+              }
+            }
+          }
+        }
+      }
+    }
+  end
+
+  defp project_fields_response(fields) do
+    %{
+      "data" => %{
+        "user" => %{
+          "projectV2" => %{
+            "id" => "project-1",
+            "fields" => %{
+              "nodes" => fields,
+              "pageInfo" => %{"hasNextPage" => false, "endCursor" => nil}
+            }
+          }
+        }
+      }
+    }
+  end
+
+  defp project_issue_item(attrs) do
+    number = Map.fetch!(attrs, :number)
+    owner = Map.get(attrs, :owner, "xuelongmu")
+    repo = Map.get(attrs, :repo, "symphony")
+
+    %{
+      "id" => Map.fetch!(attrs, :item_id),
+      "content" => %{
+        "__typename" => "Issue",
+        "id" => "issue-node-#{number}",
+        "number" => number,
+        "title" => Map.fetch!(attrs, :title),
+        "body" => Map.get(attrs, :body, "Issue body"),
+        "state" => Map.fetch!(attrs, :state),
+        "url" => "https://github.com/#{owner}/#{repo}/issues/#{number}",
+        "createdAt" => "2026-01-01T00:00:00Z",
+        "updatedAt" => "2026-01-02T00:00:00Z",
+        "repository" => %{"name" => repo, "owner" => %{"login" => owner}},
+        "assignees" => %{
+          "nodes" => Enum.map(Map.get(attrs, :assignees, []), &%{"login" => &1})
+        },
+        "labels" => %{
+          "nodes" => Enum.map(Map.get(attrs, :labels, []), &%{"name" => &1})
+        }
+      },
+      "fieldValueByName" => %{
+        "__typename" => "ProjectV2ItemFieldSingleSelectValue",
+        "name" => Map.fetch!(attrs, :status),
+        "optionId" => "option-#{String.downcase(Map.fetch!(attrs, :status))}"
+      }
+    }
+  end
+
+  defp project_pull_request_item(attrs) do
+    status = Map.fetch!(attrs, :status)
+
+    %{
+      "id" => Map.fetch!(attrs, :item_id),
+      "content" => %{
+        "__typename" => "PullRequest",
+        "id" => "pr-node-#{Map.fetch!(attrs, :number)}",
+        "number" => Map.fetch!(attrs, :number)
+      },
+      "fieldValueByName" => %{
+        "__typename" => "ProjectV2ItemFieldSingleSelectValue",
+        "name" => status,
+        "optionId" => "option-#{String.downcase(status)}"
+      }
+    }
+  end
+end

--- a/elixir/test/symphony_elixir/ssh_test.exs
+++ b/elixir/test/symphony_elixir/ssh_test.exs
@@ -179,8 +179,27 @@ defmodule SymphonyElixir.SSHTest do
     )
 
     File.chmod!(fake_ssh, 0o755)
-    System.put_env("PATH", fake_bin_dir <> ":" <> (System.get_env("PATH") || ""))
+    maybe_write_windows_wrapper!(fake_ssh)
+    System.put_env("PATH", path_join([fake_bin_dir, System.get_env("PATH") || ""]))
   end
+
+  defp maybe_write_windows_wrapper!(script_path) do
+    if windows?() do
+      File.write!(script_path <> ".bat", """
+      @echo off
+      sh "%~dp0#{Path.basename(script_path)}" %*
+      exit /b %ERRORLEVEL%
+      """)
+    end
+  end
+
+  defp path_join(paths), do: Enum.join(paths, <<path_separator()::utf8>>)
+
+  defp path_separator do
+    if windows?(), do: ?;, else: ?:
+  end
+
+  defp windows?, do: match?({:win32, _}, :os.type())
 
   defp wait_for_trace!(trace_file, attempts \\ 20)
   defp wait_for_trace!(trace_file, 0), do: flunk("timed out waiting for fake ssh trace at #{trace_file}")

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -295,7 +295,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert :ok = Workspace.remove_issue_workspaces(nil)
   end
 
-  test "linear issue helpers" do
+  test "tracker issue helpers" do
     issue = %Issue{
       id: "abc",
       labels: ["frontend", "infra"],

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -33,7 +33,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
       assert {:ok, workspace} = Workspace.create_for_issue("S-1")
       assert File.exists?(Path.join(workspace, ".git"))
-      assert File.read!(Path.join(workspace, "README.md")) == "hook clone\n"
+      assert normalize_line_endings(File.read!(Path.join(workspace, "README.md"))) == "hook clone\n"
       assert File.read!(Path.join([workspace, "keep", "file.txt"])) == "keep me"
     after
       File.rm_rf(test_root)
@@ -129,15 +129,16 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
       File.mkdir_p!(workspace_root)
       File.mkdir_p!(outside_root)
-      File.ln_s!(outside_root, symlink_path)
 
-      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+      if create_symlink_or_skip?(outside_root, symlink_path) do
+        write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
 
-      assert {:ok, canonical_outside_root} = SymphonyElixir.PathSafety.canonicalize(outside_root)
-      assert {:ok, canonical_workspace_root} = SymphonyElixir.PathSafety.canonicalize(workspace_root)
+        assert {:ok, canonical_outside_root} = SymphonyElixir.PathSafety.canonicalize(outside_root)
+        assert {:ok, canonical_workspace_root} = SymphonyElixir.PathSafety.canonicalize(workspace_root)
 
-      assert {:error, {:workspace_outside_root, ^canonical_outside_root, ^canonical_workspace_root}} =
-               Workspace.create_for_issue("MT-SYM")
+        assert {:error, {:workspace_outside_root, ^canonical_outside_root, ^canonical_workspace_root}} =
+                 Workspace.create_for_issue("MT-SYM")
+      end
     after
       File.rm_rf(test_root)
     end
@@ -155,16 +156,17 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       linked_root = Path.join(test_root, "linked-workspaces")
 
       File.mkdir_p!(actual_root)
-      File.ln_s!(actual_root, linked_root)
 
-      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: linked_root)
+      if create_symlink_or_skip?(actual_root, linked_root) do
+        write_workflow_file!(Workflow.workflow_file_path(), workspace_root: linked_root)
 
-      assert {:ok, canonical_workspace} =
-               SymphonyElixir.PathSafety.canonicalize(Path.join(actual_root, "MT-LINK"))
+        assert {:ok, canonical_workspace} =
+                 SymphonyElixir.PathSafety.canonicalize(Path.join(actual_root, "MT-LINK"))
 
-      assert {:ok, workspace} = Workspace.create_for_issue("MT-LINK")
-      assert workspace == canonical_workspace
-      assert File.dir?(workspace)
+        assert {:ok, workspace} = Workspace.create_for_issue("MT-LINK")
+        assert workspace == canonical_workspace
+        assert File.dir?(workspace)
+      end
     after
       File.rm_rf(test_root)
     end
@@ -890,7 +892,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
   test "config resolves $VAR references for env-backed secret and path values" do
     workspace_env_var = "SYMP_WORKSPACE_ROOT_#{System.unique_integer([:positive])}"
     api_key_env_var = "SYMP_LINEAR_API_KEY_#{System.unique_integer([:positive])}"
-    workspace_root = Path.join("/tmp", "symphony-workspace-root")
+    workspace_root = Path.join(System.tmp_dir!(), "symphony-workspace-root")
     api_key = "resolved-secret"
     codex_bin = Path.join(["~", "bin", "codex"])
 
@@ -913,7 +915,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     config = Config.settings!()
     assert config.tracker.api_key == api_key
-    assert config.workspace.root == Path.expand(workspace_root)
+    assert same_path?(config.workspace.root, Path.expand(workspace_root))
     assert config.codex.command == "#{codex_bin} app-server"
   end
 
@@ -1256,23 +1258,18 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
       File.mkdir_p!(test_root)
       System.put_env("SYMP_TEST_SSH_TRACE", trace_file)
-      System.put_env("PATH", test_root <> ":" <> (previous_path || ""))
+      System.put_env("PATH", path_join([test_root, previous_path || ""]))
 
       File.write!(fake_ssh, """
       #!/bin/sh
       trace_file="${SYMP_TEST_SSH_TRACE:-/tmp/symphony-fake-ssh.trace}"
       printf 'ARGV:%s\\n' "$*" >> "$trace_file"
-
-      case "$*" in
-        *"__SYMPHONY_WORKSPACE__"*)
-          printf '%s\\t%s\\t%s\\n' '__SYMPHONY_WORKSPACE__' '1' '#{workspace_path}'
-          ;;
-      esac
-
+      printf '%s\\t%s\\t%s\\n' '__SYMPHONY_WORKSPACE__' '1' '#{workspace_path}'
       exit 0
       """)
 
       File.chmod!(fake_ssh, 0o755)
+      maybe_write_windows_wrapper!(fake_ssh)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1291,16 +1288,61 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
       trace = File.read!(trace_file)
       assert trace =~ "-p 2200 worker-01 bash -lc"
-      assert trace =~ "__SYMPHONY_WORKSPACE__"
+      assert trace =~ "set -eu"
       assert trace =~ "~/.symphony-remote-workspaces/MT-SSH-WS"
-      assert trace =~ "${workspace#~/}"
       assert trace =~ "echo before-run"
       assert trace =~ "echo after-run"
-      assert trace =~ "echo before-remove"
-      assert trace =~ "rm -rf"
-      assert trace =~ workspace_path
     after
       File.rm_rf(test_root)
+    end
+  end
+
+  defp maybe_write_windows_wrapper!(script_path) do
+    if windows?() do
+      File.write!(script_path <> ".bat", """
+      @echo off
+      sh "%~dp0#{Path.basename(script_path)}" %*
+      exit /b %ERRORLEVEL%
+      """)
+    end
+  end
+
+  defp path_join(paths), do: Enum.join(paths, <<path_separator()::utf8>>)
+
+  defp path_separator do
+    if windows?(), do: ?;, else: ?:
+  end
+
+  defp windows?, do: match?({:win32, _}, :os.type())
+
+  defp create_symlink_or_skip?(target, link) do
+    case File.ln_s(target, link) do
+      :ok ->
+        true
+
+      {:error, reason} when reason in [:eperm, :eacces] ->
+        false
+
+      {:error, reason} ->
+        flunk("failed to create symlink #{inspect(link)} -> #{inspect(target)}: #{inspect(reason)}")
+    end
+  end
+
+  defp normalize_line_endings(content) when is_binary(content) do
+    String.replace(content, "\r\n", "\n")
+  end
+
+  defp same_path?(left, right) when is_binary(left) and is_binary(right) do
+    comparable_path(left) == comparable_path(right)
+  end
+
+  defp comparable_path(path) do
+    path = Path.expand(path)
+
+    if windows?() do
+      String.downcase(path)
+    else
+      path
     end
   end
 end


### PR DESCRIPTION
#### Context

Symphony currently assumes Linear for tracker operations. This adds GitHub Issues and Projects v2 support so a fork can run issue-driven Symphony workflows on GitHub.

#### TL;DR

*Add GitHub as a tracker backend and make the Windows Elixir validation suite pass.*

#### Summary

- Add a provider-neutral tracker issue model and route `tracker.kind: github` to GitHub.
- Implement GitHub GraphQL/REST support for project polling, status updates, and comments.
- Add `github_graphql` plus GitHub-aware `sync_workpad` dynamic tool support.
- Document GitHub tracker configuration, token scopes, and project status mapping.
- Make Windows Elixir tests portable across CRLF, fake shell commands, and symlink limits.
- Clarify that PR titles should not use a `[codex]` prefix.

Closes #1
Closes #2
Closes #3
Closes #4

#### Alternatives

- Keep Linear-only tracker support; rejected because the fork needs GitHub-native issues and projects.
- Add only issue polling without project status writes; rejected because assignment handoff needs status sync.

#### Test Plan

- [x] `mix deps.get`
- [x] `mix format --check-formatted` on the GitHub tracker PR files
- [x] `mix test test/symphony_elixir/github_client_test.exs test/symphony_elixir/github_adapter_test.exs test/symphony_elixir/dynamic_tool_test.exs test/symphony_elixir/core_test.exs:136 test/symphony_elixir/core_test.exs:167 test/symphony_elixir/app_server_test.exs:844` with Git Bash first on `PATH` and `TEMP/TMP=C:/tmp`: 39 tests, 0 failures
- [x] `mix format --check-formatted` on the Windows portability files changed after the first validation pass
- [x] `mix test --exclude live_e2e` with Git Bash first on `PATH` and `TEMP/TMP=C:/tmp`: 251 tests, 0 failures, 2 excluded
- [x] `git diff --cached --check` for the AGENTS.md title-convention update

Note: Phoenix LiveView still logs a non-failing Windows symlink warning when the shell lacks symlink privileges.