### PR TITLE
Clean up Elixir docs guidance

### DIFF
--- a/elixir/AGENTS.md
+++ b/elixir/AGENTS.md
@@ -49,6 +49,8 @@ mix specs.check
 ## PR Requirements
 
 - PR titles must describe the change directly; do not prefix them with `[codex]`.
+- Once a PR exists or review feedback has started, address follow-up work with new commits instead
+  of amending existing commits. Do not force-push unless explicitly requested or needed for recovery.
 - PR body must follow `../.github/pull_request_template.md` exactly.
 - Validate PR body locally when needed:
 

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -127,19 +127,26 @@ mise exec -- mix local.hex --force
 mise exec -- mix local.rebar --force
 mise exec -- mix setup
 mise exec -- mix build
-mise exec -- ./bin/symphony ./WORKFLOW.md
+mise exec -- ./bin/symphony \
+  --i-understand-that-this-will-be-running-without-the-usual-guardrails \
+  ./WORKFLOW.md
 ```
 
 On Windows, run the built escript with `escript`:
 
 ```powershell
-mise exec -- escript .\bin\symphony .\WORKFLOW.md
+mise exec -- escript .\bin\symphony `
+  --i-understand-that-this-will-be-running-without-the-usual-guardrails `
+  .\WORKFLOW.md
 ```
 
 To enable the optional dashboard while Symphony runs:
 
 ```bash
-./bin/symphony --port 4000 ./WORKFLOW.md
+./bin/symphony \
+  --i-understand-that-this-will-be-running-without-the-usual-guardrails \
+  --port 4000 \
+  ./WORKFLOW.md
 ```
 
 Then open `http://127.0.0.1:4000/`.
@@ -149,10 +156,15 @@ Then open `http://127.0.0.1:4000/`.
 Pass a custom workflow file path to `./bin/symphony` when starting the service:
 
 ```bash
-./bin/symphony /path/to/custom/WORKFLOW.md
+./bin/symphony \
+  --i-understand-that-this-will-be-running-without-the-usual-guardrails \
+  /path/to/custom/WORKFLOW.md
 ```
 
 If no path is passed, Symphony defaults to `./WORKFLOW.md`.
+
+The acknowledgement flag is required because this reference implementation starts Codex without
+the usual product guardrails.
 
 Optional flags:
 


### PR DESCRIPTION
#### Context

This is a docs cleanup pass following the Elixir setup README update and Codex review feedback. The README startup examples needed the required guardrails acknowledgement flag, and the repo instructions should discourage amend/force-push churn once PR review starts.

#### TL;DR

*Clean up Elixir docs for startup commands and PR follow-up workflow.*

#### Summary

- Add the guardrails acknowledgement flag to Elixir README startup examples.
- Note why the acknowledgement flag is required for the reference implementation.
- Document that follow-up PR work should use new commits instead of amends once review starts.

#### Alternatives

- Leave commands short and rely on the CLI error banner, but that keeps copied startup examples broken.
- Keep the PR workflow rule only as tribal knowledge, but future agents should read it from AGENTS.md.

#### Test Plan

- [ ] `make -C elixir all` fails locally at `fmt-check` because this Windows checkout reports existing Elixir source line-ending format differences.
- [x] `git diff --check origin/main...HEAD`
- [x] `make -C elixir help`