### PR TITLE
Add tracker required label gate

### DIFF
--- a/docs/github-tracker-dashboard-usage.md
+++ b/docs/github-tracker-dashboard-usage.md
@@ -14,7 +14,7 @@ A typical project setup is:
 - `In review`: work is done and waiting for review.
 - `Done`: terminal state.
 
-In the workflow config, `tracker.active_states` controls what Symphony may dispatch. For a safe first run, use only `Ready` as active. That prevents existing `In progress` issues from being picked up just because you started the dashboard.
+In the workflow config, `tracker.active_states` controls what project statuses Symphony may dispatch. To avoid taking over manually owned issues that are already `Ready` or `In progress`, also set `tracker.required_labels` to an explicit ownership label such as `symphony`.
 
 ## GitHub Setup
 
@@ -53,6 +53,8 @@ tracker:
   project_status_field: Status
   active_states:
     - Ready
+  required_labels:
+    - symphony
   terminal_states:
     - Done
     - Closed
@@ -94,6 +96,7 @@ Important fields:
 - `tracker.project_owner`, `tracker.project_owner_type`, and `tracker.project_number` identify the Project v2 board.
 - `tracker.project_status_field` names the single-select field Symphony reads.
 - `tracker.active_states` controls what can be dispatched.
+- `tracker.required_labels` optionally requires every listed label before an active issue can be dispatched.
 - `tracker.terminal_states` controls what counts as complete for cleanup.
 - `issue.id` is the raw GitHub issue number.
 - `issue.identifier` is a route-safe identifier such as `github-xuelongmu-symphony-12`.
@@ -136,10 +139,11 @@ Opening `/api/v1/refresh` directly in a browser sends `GET`, so it will not trig
 To queue a real issue:
 
 1. Create a GitHub issue in the configured repository.
-2. Add it to the configured Project v2.
-3. Set its project `Status` to one of `tracker.active_states`, for example `Ready`.
-4. Wait for the next poll or call `POST /api/v1/refresh`.
-5. Watch the dashboard.
+2. Add the `symphony` label, if `tracker.required_labels` uses that recommended gate.
+3. Add it to the configured Project v2.
+4. Set its project `Status` to one of `tracker.active_states`, for example `Ready`.
+5. Wait for the next poll or call `POST /api/v1/refresh`.
+6. Watch the dashboard.
 
 When Symphony dispatches the issue, it:
 
@@ -208,11 +212,26 @@ For initial testing, use:
 tracker:
   active_states:
     - Ready
+  required_labels:
+    - symphony
 agent:
   max_concurrent_agents: 1
 ```
 
-Then only move one disposable issue to `Ready`. This gives a controlled end-to-end run without picking up unrelated project items.
+Then label and move one disposable issue to `Ready`. This gives a controlled end-to-end run without picking up unrelated project items.
+
+For a production board where humans also use `Ready` and `In progress`, use the label as the ownership gate:
+
+```yaml
+tracker:
+  active_states:
+    - Ready
+    - In progress
+  required_labels:
+    - symphony
+```
+
+Issues without the `symphony` label remain manually owned even if their Project status is active. If a running issue loses the required label, Symphony stops and releases its active worker on the next refresh.
 
 For a busier production loop, broaden `active_states` only after the prompt and status transitions are reliable.
 
@@ -223,6 +242,7 @@ No active sessions:
 - Confirm the issue is in the configured Project v2.
 - Confirm the project field name matches `tracker.project_status_field`.
 - Confirm the field option is in `tracker.active_states`.
+- If `tracker.required_labels` is set, confirm the issue has every required label.
 - Call `POST /api/v1/refresh`.
 - Check the terminal logs for GitHub API errors.
 

--- a/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
+++ b/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
@@ -879,15 +879,6 @@ defmodule SymphonyElixir.Codex.DynamicTool do
     }
   end
 
-  defp sync_workpad_error_payload(reason) do
-    %{
-      "error" => %{
-        "message" => "sync_workpad failed.",
-        "reason" => inspect(reason)
-      }
-    }
-  end
-
   defp supported_tool_names do
     Enum.map(tool_specs(), & &1["name"])
   end

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -80,6 +80,7 @@ defmodule SymphonyElixir.Config.Schema do
       field(:assignee, :string)
       field(:active_states, {:array, :string}, default: ["Todo", "In Progress"])
       field(:terminal_states, {:array, :string}, default: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"])
+      field(:required_labels, {:array, :string}, default: [])
       embeds_one(:github, Github, on_replace: :update, defaults_to_struct: true)
     end
 
@@ -101,7 +102,8 @@ defmodule SymphonyElixir.Config.Schema do
           :project_status_field,
           :assignee,
           :active_states,
-          :terminal_states
+          :terminal_states,
+          :required_labels
         ],
         empty_values: []
       )

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -290,7 +290,7 @@ defmodule SymphonyElixir.Orchestrator do
             state,
             active_state_set(),
             terminal_state_set(),
-            required_label_set()
+            required_label_names()
           )
           |> reconcile_missing_running_issue_ids(running_ids, issues)
 
@@ -305,17 +305,17 @@ defmodule SymphonyElixir.Orchestrator do
   @doc false
   @spec reconcile_issue_states_for_test([Issue.t()], term()) :: term()
   def reconcile_issue_states_for_test(issues, %State{} = state) when is_list(issues) do
-    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set(), required_label_set())
+    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set(), required_label_names())
   end
 
   def reconcile_issue_states_for_test(issues, state) when is_list(issues) do
-    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set(), required_label_set())
+    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set(), required_label_names())
   end
 
   @doc false
   @spec should_dispatch_issue_for_test(Issue.t(), term()) :: boolean()
   def should_dispatch_issue_for_test(%Issue{} = issue, %State{} = state) do
-    should_dispatch_issue?(issue, state, active_state_set(), terminal_state_set(), required_label_set())
+    should_dispatch_issue?(issue, state, active_state_set(), terminal_state_set(), required_label_names())
   end
 
   @doc false
@@ -323,7 +323,7 @@ defmodule SymphonyElixir.Orchestrator do
           {:ok, Issue.t()} | {:skip, Issue.t() | :missing} | {:error, term()}
   def revalidate_issue_for_dispatch_for_test(%Issue{} = issue, issue_fetcher)
       when is_function(issue_fetcher, 1) do
-    revalidate_issue_for_dispatch(issue, issue_fetcher, terminal_state_set(), required_label_set())
+    revalidate_issue_for_dispatch(issue, issue_fetcher, terminal_state_set(), required_label_names())
   end
 
   @doc false
@@ -377,7 +377,7 @@ defmodule SymphonyElixir.Orchestrator do
         terminate_running_issue(state, issue.id, false)
 
       active_issue_state?(issue.state, active_states) and !issue_has_required_labels?(issue, required_labels) ->
-        Logger.info("Issue no longer has required labels: #{issue_context(issue)} required_labels=#{inspect(MapSet.to_list(required_labels))}; stopping active agent")
+        Logger.info("Issue no longer has required labels: #{issue_context(issue)} required_labels=#{inspect(required_labels)}; stopping active agent")
 
         terminate_running_issue(state, issue.id, false)
 
@@ -551,7 +551,7 @@ defmodule SymphonyElixir.Orchestrator do
   defp choose_issues(issues, state) do
     active_states = active_state_set()
     terminal_states = terminal_state_set()
-    required_labels = required_label_set()
+    required_labels = required_label_names()
 
     issues
     |> sort_issues_for_dispatch()
@@ -661,19 +661,14 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp issue_blocked_by_non_terminal?(_issue, _terminal_states), do: false
 
-  defp issue_has_required_labels?(issue, required_labels) do
-    if MapSet.size(required_labels) == 0 do
-      true
-    else
-      do_issue_has_required_labels?(issue, required_labels)
-    end
+  defp issue_has_required_labels?(_issue, []), do: true
+
+  defp issue_has_required_labels?(%Issue{labels: labels}, required_labels) when is_list(labels) do
+    issue_labels = normalized_label_names(labels)
+    Enum.all?(required_labels, &(&1 in issue_labels))
   end
 
-  defp do_issue_has_required_labels?(%Issue{labels: labels}, required_labels) when is_list(labels) do
-    MapSet.subset?(required_labels, normalized_label_set(labels))
-  end
-
-  defp do_issue_has_required_labels?(_issue, _required_labels), do: false
+  defp issue_has_required_labels?(_issue, _required_labels), do: false
 
   defp terminal_issue_state?(state_name, terminal_states) when is_binary(state_name) do
     MapSet.member?(terminal_states, normalize_issue_state(state_name))
@@ -703,22 +698,22 @@ defmodule SymphonyElixir.Orchestrator do
     |> MapSet.new()
   end
 
-  defp required_label_set do
+  defp required_label_names do
     Config.settings!().tracker.required_labels
-    |> normalized_label_set()
+    |> normalized_label_names()
   end
 
-  defp normalized_label_set(labels) when is_list(labels) do
+  defp normalized_label_names(labels) when is_list(labels) do
     labels
     |> Enum.flat_map(fn
       label when is_binary(label) -> [normalize_label_name(label)]
       _ -> []
     end)
     |> Enum.filter(&(&1 != ""))
-    |> MapSet.new()
+    |> Enum.uniq()
   end
 
-  defp normalized_label_set(_labels), do: MapSet.new()
+  defp normalized_label_names(_labels), do: []
 
   defp normalize_label_name(label) when is_binary(label) do
     label
@@ -731,7 +726,7 @@ defmodule SymphonyElixir.Orchestrator do
            issue,
            &Tracker.fetch_issue_states_by_ids/1,
            terminal_state_set(),
-           required_label_set()
+           required_label_names()
          ) do
       {:ok, %Issue{} = refreshed_issue} ->
         maybe_dispatch_or_handoff_review_limit(state, refreshed_issue, attempt, preferred_worker_host)
@@ -1008,7 +1003,7 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp handle_retry_issue_lookup(%Issue{} = issue, state, issue_id, attempt, metadata) do
     terminal_states = terminal_state_set()
-    required_labels = required_label_set()
+    required_labels = required_label_names()
     state = clear_review_round_unless_review_state(state, issue)
 
     cond do
@@ -1063,7 +1058,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp handle_active_retry(state, issue, attempt, metadata) do
-    if retry_candidate_issue?(issue, terminal_state_set(), required_label_set()) and
+    if retry_candidate_issue?(issue, terminal_state_set(), required_label_names()) and
          dispatch_slots_available?(issue, state) and
          worker_slots_available?(state, metadata[:worker_host]) do
       {:noreply, dispatch_issue(state, issue, attempt, metadata[:worker_host])}

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -289,7 +289,8 @@ defmodule SymphonyElixir.Orchestrator do
           |> reconcile_running_issue_states(
             state,
             active_state_set(),
-            terminal_state_set()
+            terminal_state_set(),
+            required_label_set()
           )
           |> reconcile_missing_running_issue_ids(running_ids, issues)
 
@@ -304,17 +305,17 @@ defmodule SymphonyElixir.Orchestrator do
   @doc false
   @spec reconcile_issue_states_for_test([Issue.t()], term()) :: term()
   def reconcile_issue_states_for_test(issues, %State{} = state) when is_list(issues) do
-    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set())
+    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set(), required_label_set())
   end
 
   def reconcile_issue_states_for_test(issues, state) when is_list(issues) do
-    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set())
+    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set(), required_label_set())
   end
 
   @doc false
   @spec should_dispatch_issue_for_test(Issue.t(), term()) :: boolean()
   def should_dispatch_issue_for_test(%Issue{} = issue, %State{} = state) do
-    should_dispatch_issue?(issue, state, active_state_set(), terminal_state_set())
+    should_dispatch_issue?(issue, state, active_state_set(), terminal_state_set(), required_label_set())
   end
 
   @doc false
@@ -322,7 +323,7 @@ defmodule SymphonyElixir.Orchestrator do
           {:ok, Issue.t()} | {:skip, Issue.t() | :missing} | {:error, term()}
   def revalidate_issue_for_dispatch_for_test(%Issue{} = issue, issue_fetcher)
       when is_function(issue_fetcher, 1) do
-    revalidate_issue_for_dispatch(issue, issue_fetcher, terminal_state_set())
+    revalidate_issue_for_dispatch(issue, issue_fetcher, terminal_state_set(), required_label_set())
   end
 
   @doc false
@@ -349,18 +350,19 @@ defmodule SymphonyElixir.Orchestrator do
     dispatch_issue(state, issue)
   end
 
-  defp reconcile_running_issue_states([], state, _active_states, _terminal_states), do: state
+  defp reconcile_running_issue_states([], state, _active_states, _terminal_states, _required_labels), do: state
 
-  defp reconcile_running_issue_states([issue | rest], state, active_states, terminal_states) do
+  defp reconcile_running_issue_states([issue | rest], state, active_states, terminal_states, required_labels) do
     reconcile_running_issue_states(
       rest,
-      reconcile_issue_state(issue, state, active_states, terminal_states),
+      reconcile_issue_state(issue, state, active_states, terminal_states, required_labels),
       active_states,
-      terminal_states
+      terminal_states,
+      required_labels
     )
   end
 
-  defp reconcile_issue_state(%Issue{} = issue, state, active_states, terminal_states) do
+  defp reconcile_issue_state(%Issue{} = issue, state, active_states, terminal_states, required_labels) do
     state = clear_review_round_unless_review_state(state, issue)
 
     cond do
@@ -371,6 +373,11 @@ defmodule SymphonyElixir.Orchestrator do
 
       !issue_routable_to_worker?(issue) ->
         Logger.info("Issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; stopping active agent")
+
+        terminate_running_issue(state, issue.id, false)
+
+      active_issue_state?(issue.state, active_states) and !issue_has_required_labels?(issue, required_labels) ->
+        Logger.info("Issue no longer has required labels: #{issue_context(issue)} required_labels=#{inspect(MapSet.to_list(required_labels))}; stopping active agent")
 
         terminate_running_issue(state, issue.id, false)
 
@@ -388,7 +395,7 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
-  defp reconcile_issue_state(_issue, state, _active_states, _terminal_states), do: state
+  defp reconcile_issue_state(_issue, state, _active_states, _terminal_states, _required_labels), do: state
 
   defp reconcile_missing_running_issue_ids(%State{} = state, requested_issue_ids, issues)
        when is_list(requested_issue_ids) and is_list(issues) do
@@ -544,11 +551,12 @@ defmodule SymphonyElixir.Orchestrator do
   defp choose_issues(issues, state) do
     active_states = active_state_set()
     terminal_states = terminal_state_set()
+    required_labels = required_label_set()
 
     issues
     |> sort_issues_for_dispatch()
     |> Enum.reduce(state, fn issue, state_acc ->
-      if should_dispatch_issue?(issue, state_acc, active_states, terminal_states) do
+      if should_dispatch_issue?(issue, state_acc, active_states, terminal_states, required_labels) do
         dispatch_issue(state_acc, issue)
       else
         state_acc
@@ -580,9 +588,10 @@ defmodule SymphonyElixir.Orchestrator do
          %Issue{} = issue,
          %State{running: running, claimed: claimed} = state,
          active_states,
-         terminal_states
+         terminal_states,
+         required_labels
        ) do
-    candidate_issue?(issue, active_states, terminal_states) and
+    candidate_issue?(issue, active_states, terminal_states, required_labels) and
       !issue_blocked_by_non_terminal?(issue, terminal_states) and
       !MapSet.member?(claimed, issue.id) and
       !Map.has_key?(running, issue.id) and
@@ -591,7 +600,7 @@ defmodule SymphonyElixir.Orchestrator do
       worker_slots_available?(state)
   end
 
-  defp should_dispatch_issue?(_issue, _state, _active_states, _terminal_states), do: false
+  defp should_dispatch_issue?(_issue, _state, _active_states, _terminal_states, _required_labels), do: false
 
   defp state_slots_available?(%Issue{state: issue_state}, running) when is_map(running) do
     limit = Config.max_concurrent_agents_for_state(issue_state)
@@ -621,15 +630,17 @@ defmodule SymphonyElixir.Orchestrator do
            state: state_name
          } = issue,
          active_states,
-         terminal_states
+         terminal_states,
+         required_labels
        )
        when is_binary(id) and is_binary(identifier) and is_binary(title) and is_binary(state_name) do
     issue_routable_to_worker?(issue) and
       active_issue_state?(state_name, active_states) and
-      !terminal_issue_state?(state_name, terminal_states)
+      !terminal_issue_state?(state_name, terminal_states) and
+      issue_has_required_labels?(issue, required_labels)
   end
 
-  defp candidate_issue?(_issue, _active_states, _terminal_states), do: false
+  defp candidate_issue?(_issue, _active_states, _terminal_states, _required_labels), do: false
 
   defp issue_routable_to_worker?(%Issue{assigned_to_worker: assigned_to_worker})
        when is_boolean(assigned_to_worker),
@@ -649,6 +660,20 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp issue_blocked_by_non_terminal?(_issue, _terminal_states), do: false
+
+  defp issue_has_required_labels?(issue, required_labels) do
+    if MapSet.size(required_labels) == 0 do
+      true
+    else
+      do_issue_has_required_labels?(issue, required_labels)
+    end
+  end
+
+  defp do_issue_has_required_labels?(%Issue{labels: labels}, required_labels) when is_list(labels) do
+    MapSet.subset?(required_labels, normalized_label_set(labels))
+  end
+
+  defp do_issue_has_required_labels?(_issue, _required_labels), do: false
 
   defp terminal_issue_state?(state_name, terminal_states) when is_binary(state_name) do
     MapSet.member?(terminal_states, normalize_issue_state(state_name))
@@ -678,8 +703,36 @@ defmodule SymphonyElixir.Orchestrator do
     |> MapSet.new()
   end
 
+  defp required_label_set do
+    Config.settings!().tracker.required_labels
+    |> normalized_label_set()
+  end
+
+  defp normalized_label_set(labels) when is_list(labels) do
+    labels
+    |> Enum.flat_map(fn
+      label when is_binary(label) -> [normalize_label_name(label)]
+      _ -> []
+    end)
+    |> Enum.filter(&(&1 != ""))
+    |> MapSet.new()
+  end
+
+  defp normalized_label_set(_labels), do: MapSet.new()
+
+  defp normalize_label_name(label) when is_binary(label) do
+    label
+    |> String.trim()
+    |> String.downcase()
+  end
+
   defp dispatch_issue(%State{} = state, issue, attempt \\ nil, preferred_worker_host \\ nil) do
-    case revalidate_issue_for_dispatch(issue, &Tracker.fetch_issue_states_by_ids/1, terminal_state_set()) do
+    case revalidate_issue_for_dispatch(
+           issue,
+           &Tracker.fetch_issue_states_by_ids/1,
+           terminal_state_set(),
+           required_label_set()
+         ) do
       {:ok, %Issue{} = refreshed_issue} ->
         maybe_dispatch_or_handoff_review_limit(state, refreshed_issue, attempt, preferred_worker_host)
 
@@ -849,11 +902,11 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
-  defp revalidate_issue_for_dispatch(%Issue{id: issue_id}, issue_fetcher, terminal_states)
+  defp revalidate_issue_for_dispatch(%Issue{id: issue_id}, issue_fetcher, terminal_states, required_labels)
        when is_binary(issue_id) and is_function(issue_fetcher, 1) do
     case issue_fetcher.([issue_id]) do
       {:ok, [%Issue{} = refreshed_issue | _]} ->
-        if retry_candidate_issue?(refreshed_issue, terminal_states) do
+        if retry_candidate_issue?(refreshed_issue, terminal_states, required_labels) do
           {:ok, refreshed_issue}
         else
           {:skip, refreshed_issue}
@@ -867,7 +920,7 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
-  defp revalidate_issue_for_dispatch(issue, _issue_fetcher, _terminal_states), do: {:ok, issue}
+  defp revalidate_issue_for_dispatch(issue, _issue_fetcher, _terminal_states, _required_labels), do: {:ok, issue}
 
   defp complete_issue(%State{} = state, issue_id) do
     %{
@@ -955,6 +1008,7 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp handle_retry_issue_lookup(%Issue{} = issue, state, issue_id, attempt, metadata) do
     terminal_states = terminal_state_set()
+    required_labels = required_label_set()
     state = clear_review_round_unless_review_state(state, issue)
 
     cond do
@@ -964,7 +1018,7 @@ defmodule SymphonyElixir.Orchestrator do
         cleanup_issue_workspace(issue.identifier, metadata[:worker_host])
         {:noreply, release_issue_claim(state, issue_id)}
 
-      retry_candidate_issue?(issue, terminal_states) ->
+      retry_candidate_issue?(issue, terminal_states, required_labels) ->
         handle_active_retry(state, issue, attempt, metadata)
 
       true ->
@@ -1009,7 +1063,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp handle_active_retry(state, issue, attempt, metadata) do
-    if retry_candidate_issue?(issue, terminal_state_set()) and
+    if retry_candidate_issue?(issue, terminal_state_set(), required_label_set()) and
          dispatch_slots_available?(issue, state) and
          worker_slots_available?(state, metadata[:worker_host]) do
       {:noreply, dispatch_issue(state, issue, attempt, metadata[:worker_host])}
@@ -1412,8 +1466,8 @@ defmodule SymphonyElixir.Orchestrator do
     }
   end
 
-  defp retry_candidate_issue?(%Issue{} = issue, terminal_states) do
-    candidate_issue?(issue, active_state_set(), terminal_states) and
+  defp retry_candidate_issue?(%Issue{} = issue, terminal_states, required_labels) do
+    candidate_issue?(issue, active_state_set(), terminal_states, required_labels) and
       !issue_blocked_by_non_terminal?(issue, terminal_states)
   end
 

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -110,6 +110,7 @@ defmodule SymphonyElixir.TestSupport do
           tracker_assignee: nil,
           tracker_active_states: ["Todo", "In Progress"],
           tracker_terminal_states: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"],
+          tracker_required_labels: [],
           poll_interval_ms: 30_000,
           workspace_root: Path.join(System.tmp_dir!(), "symphony_workspaces"),
           worker_ssh_hosts: [],
@@ -160,6 +161,7 @@ defmodule SymphonyElixir.TestSupport do
     tracker_assignee = Keyword.get(config, :tracker_assignee)
     tracker_active_states = Keyword.get(config, :tracker_active_states)
     tracker_terminal_states = Keyword.get(config, :tracker_terminal_states)
+    tracker_required_labels = Keyword.get(config, :tracker_required_labels)
     poll_interval_ms = Keyword.get(config, :poll_interval_ms)
     workspace_root = Keyword.get(config, :workspace_root)
     worker_ssh_hosts = Keyword.get(config, :worker_ssh_hosts)
@@ -213,6 +215,7 @@ defmodule SymphonyElixir.TestSupport do
         "  assignee: #{yaml_value(tracker_assignee)}",
         "  active_states: #{yaml_value(tracker_active_states)}",
         "  terminal_states: #{yaml_value(tracker_terminal_states)}",
+        "  required_labels: #{yaml_value(tracker_required_labels)}",
         "polling:",
         "  interval_ms: #{yaml_value(poll_interval_ms)}",
         "workspace:",

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -131,7 +131,8 @@ defmodule SymphonyElixir.CoreTest do
       tracker_github_status_field: "Workflow State",
       review_enabled: true,
       review_state: "Agent Review",
-      review_max_rounds: 4
+      review_max_rounds: 4,
+      tracker_active_states: ["Todo", "In Progress", "Agent Review"]
     )
 
     assert :ok = Config.validate!()

--- a/elixir/test/symphony_elixir/path_safety_test.exs
+++ b/elixir/test/symphony_elixir/path_safety_test.exs
@@ -1,0 +1,67 @@
+defmodule SymphonyElixir.PathSafetyTest do
+  use ExUnit.Case, async: false
+
+  alias SymphonyElixir.PathSafety
+
+  test "canonicalize resolves existing symlink path segments" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-path-safety-symlink-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      actual_root = Path.join(test_root, "actual")
+      linked_root = Path.join(test_root, "linked")
+      nested_path = Path.join(actual_root, "nested")
+      expected_path = Path.expand(nested_path)
+
+      File.mkdir_p!(nested_path)
+
+      case File.ln_s(actual_root, linked_root) do
+        :ok ->
+          assert {:ok, ^expected_path} =
+                   PathSafety.canonicalize(Path.join(linked_root, "nested"))
+
+        {:error, reason} when reason in [:eperm, :eacces] ->
+          :ok
+
+        {:error, reason} ->
+          flunk("failed to create symlink #{inspect(linked_root)}: #{inspect(reason)}")
+      end
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "canonicalize returns non-enoent lstat errors" do
+    if windows?() do
+      :ok
+    else
+      test_root =
+        Path.join(
+          System.tmp_dir!(),
+          "symphony-elixir-path-safety-lstat-error-#{System.unique_integer([:positive])}"
+        )
+
+      locked_path = Path.join(test_root, "locked")
+      child_path = Path.join(locked_path, "child")
+      expanded_path = Path.expand(child_path)
+
+      try do
+        File.mkdir_p!(locked_path)
+        :ok = File.chmod(locked_path, 0o000)
+
+        assert {:error, {:path_canonicalize_failed, ^expanded_path, reason}} =
+                 PathSafety.canonicalize(child_path)
+
+        assert reason in [:eacces, :eperm]
+      after
+        File.chmod(locked_path, 0o700)
+        File.rm_rf(test_root)
+      end
+    end
+  end
+
+  defp windows?, do: match?({:win32, _}, :os.type())
+end

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -309,6 +309,21 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     refute issue.assigned_to_worker
   end
 
+  test "config parses tracker required labels and defaults to none" do
+    assert {:ok, settings} = Schema.parse(%{tracker: %{kind: "memory"}})
+    assert settings.tracker.required_labels == []
+
+    assert {:ok, settings} =
+             Schema.parse(%{
+               tracker: %{
+                 kind: "github",
+                 required_labels: ["symphony", "agent-owned"]
+               }
+             })
+
+    assert settings.tracker.required_labels == ["symphony", "agent-owned"]
+  end
+
   test "linear client normalizes blockers from inverse relations" do
     raw_issue = %{
       "id" => "issue-1",
@@ -670,6 +685,74 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     refute Orchestrator.should_dispatch_issue_for_test(issue, state)
   end
 
+  test "default empty required labels keep active unlabeled issues dispatch-eligible" do
+    state = %Orchestrator.State{
+      max_concurrent_agents: 3,
+      running: %{},
+      claimed: MapSet.new(),
+      codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      retry_attempts: %{}
+    }
+
+    issue = %Issue{
+      id: "unlabeled-1",
+      identifier: "MT-1008",
+      title: "Unlabeled active work",
+      state: "In Progress",
+      labels: []
+    }
+
+    assert Orchestrator.should_dispatch_issue_for_test(issue, state)
+  end
+
+  test "active issue with required label dispatches with trimmed case-insensitive matching" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_required_labels: [" symphony "])
+
+    state = %Orchestrator.State{
+      max_concurrent_agents: 3,
+      running: %{},
+      claimed: MapSet.new(),
+      codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      retry_attempts: %{}
+    }
+
+    issue = %Issue{
+      id: "labeled-1",
+      identifier: "MT-1009",
+      title: "Labeled active work",
+      state: "In Progress",
+      labels: ["  SyMpHoNy  "]
+    }
+
+    assert Orchestrator.should_dispatch_issue_for_test(issue, state)
+  end
+
+  test "active issue without required label is not dispatch-eligible" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_required_labels: ["symphony", "agent-owned"])
+
+    state = %Orchestrator.State{
+      max_concurrent_agents: 3,
+      running: %{},
+      claimed: MapSet.new(),
+      codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      retry_attempts: %{}
+    }
+
+    issue = %Issue{
+      id: "manual-1",
+      identifier: "MT-1010",
+      title: "Manual active work",
+      state: "In Progress",
+      labels: ["manual"]
+    }
+
+    refute Orchestrator.should_dispatch_issue_for_test(issue, state)
+
+    partially_labeled_issue = %{issue | id: "manual-2", labels: ["symphony"]}
+
+    refute Orchestrator.should_dispatch_issue_for_test(partially_labeled_issue, state)
+  end
+
   test "active issue with terminal blockers remains dispatch-eligible" do
     state = %Orchestrator.State{
       max_concurrent_agents: 3,
@@ -714,6 +797,81 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     assert skipped_issue.identifier == "MT-1005"
     assert skipped_issue.blocked_by == [%{id: "blocker-3", identifier: "MT-1006", state: "In Progress"}]
+  end
+
+  test "dispatch revalidation skips stale active issue once required label is removed" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_required_labels: ["symphony"])
+
+    stale_issue = %Issue{
+      id: "label-stale-1",
+      identifier: "MT-1011",
+      title: "Stale labeled work",
+      state: "In Progress",
+      labels: ["symphony"]
+    }
+
+    refreshed_issue = %Issue{
+      id: "label-stale-1",
+      identifier: "MT-1011",
+      title: "Stale labeled work",
+      state: "In Progress",
+      labels: []
+    }
+
+    fetcher = fn ["label-stale-1"] -> {:ok, [refreshed_issue]} end
+
+    assert {:skip, %Issue{} = skipped_issue} =
+             Orchestrator.revalidate_issue_for_dispatch_for_test(stale_issue, fetcher)
+
+    assert skipped_issue.identifier == "MT-1011"
+    assert skipped_issue.labels == []
+  end
+
+  test "reconcile stops and releases running issue when required label is removed" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_required_labels: ["symphony"])
+
+    issue_id = "label-running-1"
+
+    agent_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    state = %Orchestrator.State{
+      running: %{
+        issue_id => %{
+          pid: agent_pid,
+          ref: nil,
+          identifier: "MT-1012",
+          issue: %Issue{
+            id: issue_id,
+            identifier: "MT-1012",
+            state: "In Progress",
+            labels: ["symphony"]
+          },
+          started_at: DateTime.utc_now()
+        }
+      },
+      claimed: MapSet.new([issue_id]),
+      codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      retry_attempts: %{}
+    }
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-1012",
+      title: "No longer owned",
+      state: "In Progress",
+      labels: []
+    }
+
+    updated_state = Orchestrator.reconcile_issue_states_for_test([issue], state)
+
+    refute Map.has_key?(updated_state.running, issue_id)
+    refute MapSet.member?(updated_state.claimed, issue_id)
+    refute Process.alive?(agent_pid)
   end
 
   test "workspace remove returns error information for missing directory" do


### PR DESCRIPTION
#### Context

Project status alone lets Symphony pick up manually owned GitHub issues. Add an explicit label gate so only owned issues dispatch.

#### TL;DR

*Require configured tracker labels before Symphony dispatches active issues.*

#### Summary

- Add `tracker.required_labels` with an empty default for backward compatibility.
- Require all configured labels during dispatch, retry, revalidation, and refresh.
- Stop and release running issues that lose a required label.
- Document the recommended GitHub `symphony` label workflow.
- Cover label-gate behavior plus CI-required PathSafety branches.

#### Alternatives

- Status-only ownership was kept as the default by leaving `required_labels` empty.
- A GitHub-only option was avoided so the same ownership gate works for all trackers.

#### Test Plan

- [x] `make -C elixir all` (GitHub `make-all` check passed)
- [x] `mix format`
- [x] `mix format --check-formatted`
- [x] Targeted PathSafety, config, and orchestrator tests: 14 tests, 0 failures
- [x] `mix dialyzer --format short`
- [x] `mix pr_body.check --file <body>`