### PR TITLE
Route review exhaustion to Needs Human

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Symphony
+
+@elixir/AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,1 @@
-# Symphony
-
 @elixir/AGENTS.md

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -272,7 +272,7 @@ Notes:
 - `review.enabled` enables the automated `Agent Review` role/state loop. Review agents inspect and
   route PRs but do not make implementation changes.
 - `review.max_rounds` caps automated review-agent dispatches before Symphony hands the issue to
-  `Human Review`. Default: `3`.
+  `Needs Human`. Default: `3`.
 - If the Markdown body is blank, Symphony uses a default prompt template that includes the issue
   identifier, title, agent role, and body.
 - Use `hooks.after_create` to bootstrap a fresh workspace. For a Git-backed repo, you can run

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -14,7 +14,7 @@ defmodule SymphonyElixir.Orchestrator do
   @failure_retry_base_ms 10_000
   # Slightly above the dashboard render interval so "checking now…" can render.
   @poll_transition_render_delay_ms 20
-  @human_review_state "Human Review"
+  @human_review_state "Needs Human"
   @empty_codex_totals %{
     input_tokens: 0,
     output_tokens: 0,

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -249,7 +249,7 @@ defmodule SymphonyElixir.CoreTest do
 
     updated_state = Orchestrator.dispatch_issue_for_test(state, issue)
 
-    assert_receive {:memory_tracker_state_update, "issue-review-cap", "Human Review"}
+    assert_receive {:memory_tracker_state_update, "issue-review-cap", "Needs Human"}
     refute Map.has_key?(updated_state.running, issue.id)
     refute Map.has_key?(updated_state.review_rounds, issue.id)
     refute MapSet.member?(updated_state.claimed, issue.id)


### PR DESCRIPTION
#### Context

Automated review-round exhaustion should hand off to the GitHub Project status that explicitly requests manual attention.

#### TL;DR

*Review exhaustion now routes to Needs Human and root guidance points to Elixir instructions.*

#### Summary

- Change the Elixir orchestrator handoff status to `Needs Human`.
- Update the focused exhaustion assertion for the new project status.
- Document the `review.max_rounds` behavior in the Elixir README.
- Add root `AGENTS.md` pointing to `elixir/AGENTS.md` for root-launched sessions.

#### Alternatives

- Keep `Human Review`, but that no longer matches the desired project workflow state.
- Duplicate Elixir guidance at the repo root, but a pointer avoids divergent instructions.

#### Test Plan

- [x] `mix test test/symphony_elixir/core_test.exs:233`
- [x] `mix pr_body.check --file C:\Users\xuelo\AppData\Local\Temp\symphony-review-exhaustion-pr-body.md`
- [ ] `make -C elixir all` (fails in `mix format --check-formatted` on unrelated existing files)