### PR TITLE
[codex] Add session activity observability

### DIFF
--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -16,6 +16,7 @@ defmodule SymphonyElixir.Orchestrator do
   @poll_transition_render_delay_ms 20
   @human_review_state "Human Review"
   @session_history_limit 50
+  @codex_event_history_limit 20
   @empty_codex_totals %{
     input_tokens: 0,
     output_tokens: 0,
@@ -894,6 +895,7 @@ defmodule SymphonyElixir.Orchestrator do
             last_codex_message: nil,
             last_codex_timestamp: nil,
             last_codex_event: nil,
+            recent_codex_messages: [],
             codex_app_server_pid: nil,
             codex_input_tokens: 0,
             codex_output_tokens: 0,
@@ -1248,6 +1250,7 @@ defmodule SymphonyElixir.Orchestrator do
       last_codex_timestamp: Map.get(running_entry, :last_codex_timestamp),
       last_codex_message: Map.get(running_entry, :last_codex_message),
       last_codex_event: Map.get(running_entry, :last_codex_event),
+      recent_codex_messages: Map.get(running_entry, :recent_codex_messages, []),
       codex_input_tokens: Map.get(running_entry, :codex_input_tokens, 0),
       codex_output_tokens: Map.get(running_entry, :codex_output_tokens, 0),
       codex_total_tokens: Map.get(running_entry, :codex_total_tokens, 0)
@@ -1441,6 +1444,7 @@ defmodule SymphonyElixir.Orchestrator do
           last_codex_timestamp: metadata.last_codex_timestamp,
           last_codex_message: metadata.last_codex_message,
           last_codex_event: metadata.last_codex_event,
+          recent_codex_messages: Map.get(metadata, :recent_codex_messages, []),
           runtime_seconds: running_seconds(metadata.started_at, now)
         }
       end)
@@ -1512,6 +1516,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp integrate_codex_update(running_entry, %{event: event, timestamp: timestamp} = update) do
+    summarized_update = summarize_codex_update(update)
     token_delta = extract_token_delta(running_entry, update)
     codex_input_tokens = Map.get(running_entry, :codex_input_tokens, 0)
     codex_output_tokens = Map.get(running_entry, :codex_output_tokens, 0)
@@ -1525,9 +1530,10 @@ defmodule SymphonyElixir.Orchestrator do
     {
       Map.merge(running_entry, %{
         last_codex_timestamp: timestamp,
-        last_codex_message: summarize_codex_update(update),
+        last_codex_message: summarized_update,
         session_id: session_id_for_update(running_entry.session_id, update),
         last_codex_event: event,
+        recent_codex_messages: append_recent_codex_message(running_entry, summarized_update),
         codex_app_server_pid: codex_app_server_pid_for_update(codex_app_server_pid, update),
         codex_input_tokens: codex_input_tokens + token_delta.input_tokens,
         codex_output_tokens: codex_output_tokens + token_delta.output_tokens,
@@ -1583,6 +1589,11 @@ defmodule SymphonyElixir.Orchestrator do
       message: update[:payload] || update[:raw],
       timestamp: update[:timestamp]
     }
+  end
+
+  defp append_recent_codex_message(running_entry, summarized_update) do
+    [summarized_update | Map.get(running_entry, :recent_codex_messages, [])]
+    |> Enum.take(@codex_event_history_limit)
   end
 
   defp schedule_tick(%State{} = state, delay_ms) when is_integer(delay_ms) and delay_ms >= 0 do

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -257,6 +257,22 @@ defmodule SymphonyElixirWeb.DashboardLive do
                             · <span class="mono numeric"><%= entry.last_event_at %></span>
                           <% end %>
                         </span>
+                        <%= if entry.recent_events != [] do %>
+                          <details class="event-history">
+                            <summary>Activity (<%= length(entry.recent_events) %>)</summary>
+                            <ol>
+                              <li :for={event <- entry.recent_events}>
+                                <span class="event-history-message"><%= event.message || "n/a" %></span>
+                                <span class="muted event-history-meta">
+                                  <%= event.event || "n/a" %>
+                                  <%= if event.at do %>
+                                    · <span class="mono numeric"><%= event.at %></span>
+                                  <% end %>
+                                </span>
+                              </li>
+                            </ol>
+                          </details>
+                        <% end %>
                       </div>
                     </td>
                     <td>
@@ -420,6 +436,22 @@ defmodule SymphonyElixirWeb.DashboardLive do
                             · <span class="mono numeric"><%= entry.last_event_at %></span>
                           <% end %>
                         </span>
+                        <%= if entry.recent_events != [] do %>
+                          <details class="event-history">
+                            <summary>Activity (<%= length(entry.recent_events) %>)</summary>
+                            <ol>
+                              <li :for={event <- entry.recent_events}>
+                                <span class="event-history-message"><%= event.message || "n/a" %></span>
+                                <span class="muted event-history-meta">
+                                  <%= event.event || "n/a" %>
+                                  <%= if event.at do %>
+                                    · <span class="mono numeric"><%= event.at %></span>
+                                  <% end %>
+                                </span>
+                              </li>
+                            </ol>
+                          </details>
+                        <% end %>
                       </div>
                     </td>
                     <td>

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -130,6 +130,7 @@ defmodule SymphonyElixirWeb.Presenter do
       turn_count: Map.get(entry, :turn_count, 0),
       last_event: entry.last_codex_event,
       last_message: summarize_message(entry.last_codex_message),
+      recent_events: recent_events_payload(entry),
       started_at: iso8601(entry.started_at),
       last_event_at: iso8601(entry.last_codex_timestamp),
       tokens: %{
@@ -167,6 +168,7 @@ defmodule SymphonyElixirWeb.Presenter do
       turn_count: Map.get(entry, :turn_count, 0),
       last_event: entry.last_codex_event,
       last_message: summarize_message(entry.last_codex_message),
+      recent_events: recent_events_payload(entry),
       started_at: iso8601(entry.started_at),
       ended_at: iso8601(entry.ended_at),
       last_event_at: iso8601(entry.last_codex_timestamp),
@@ -190,6 +192,7 @@ defmodule SymphonyElixirWeb.Presenter do
       started_at: iso8601(running.started_at),
       last_event: running.last_codex_event,
       last_message: summarize_message(running.last_codex_message),
+      recent_events: recent_events_payload(running),
       last_event_at: iso8601(running.last_codex_timestamp),
       tokens: %{
         input_tokens: running.codex_input_tokens,
@@ -221,14 +224,36 @@ defmodule SymphonyElixirWeb.Presenter do
   end
 
   defp recent_events_payload(running) do
-    [
-      %{
-        at: iso8601(running.last_codex_timestamp),
-        event: running.last_codex_event,
-        message: summarize_message(running.last_codex_message)
-      }
-    ]
-    |> Enum.reject(&is_nil(&1.at))
+    case Map.get(running, :recent_codex_messages) do
+      messages when is_list(messages) and messages != [] ->
+        Enum.map(messages, &recent_event_payload/1)
+
+      _ ->
+        [
+          %{
+            at: iso8601(running.last_codex_timestamp),
+            event: running.last_codex_event,
+            message: summarize_message(running.last_codex_message)
+          }
+        ]
+        |> Enum.reject(&is_nil(&1.at))
+    end
+  end
+
+  defp recent_event_payload(message) when is_map(message) do
+    %{
+      at: iso8601(Map.get(message, :timestamp) || Map.get(message, "timestamp")),
+      event: Map.get(message, :event) || Map.get(message, "event"),
+      message: summarize_message(message)
+    }
+  end
+
+  defp recent_event_payload(message) do
+    %{
+      at: nil,
+      event: nil,
+      message: summarize_message(message)
+    }
   end
 
   defp summarize_message(nil), do: nil

--- a/elixir/priv/static/dashboard.css
+++ b/elixir/priv/static/dashboard.css
@@ -387,6 +387,51 @@ pre,
   white-space: nowrap;
 }
 
+.event-history {
+  margin-top: 0.28rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(9, 11, 10, 0.52);
+}
+
+.event-history summary {
+  padding: 0.38rem 0.55rem;
+  color: var(--accent-ink);
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.event-history ol {
+  display: grid;
+  gap: 0.55rem;
+  max-height: 18rem;
+  margin: 0;
+  padding: 0.2rem 0.65rem 0.7rem 1.55rem;
+  overflow: auto;
+}
+
+.event-history li {
+  padding-left: 0.1rem;
+}
+
+.event-history-message,
+.event-history-meta {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.event-history-message {
+  color: var(--ink);
+  line-height: 1.38;
+}
+
+.event-history-meta {
+  margin-top: 0.1rem;
+  font-size: 0.78rem;
+}
+
 .state-badge {
   display: inline-flex;
   align-items: center;

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -475,6 +475,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "turn_count" => 7,
                  "last_event" => "notification",
                  "last_message" => "rendered",
+                 "recent_events" => [],
                  "started_at" => state_payload["running"] |> List.first() |> Map.fetch!("started_at"),
                  "last_event_at" => nil,
                  "tokens" => %{"input_tokens" => 4, "output_tokens" => 8, "total_tokens" => 12}
@@ -506,6 +507,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "turn_count" => 3,
                  "last_event" => "turn_completed",
                  "last_message" => "turn completed (completed)",
+                 "recent_events" => [],
                  "started_at" => state_payload["past_sessions"] |> List.first() |> Map.fetch!("started_at"),
                  "ended_at" => state_payload["past_sessions"] |> List.first() |> Map.fetch!("ended_at"),
                  "last_event_at" => nil,
@@ -545,6 +547,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                "started_at" => issue_payload["running"]["started_at"],
                "last_event" => "notification",
                "last_message" => "rendered",
+               "recent_events" => [],
                "last_event_at" => nil,
                "tokens" => %{"input_tokens" => 4, "output_tokens" => 8, "total_tokens" => 12}
              },
@@ -770,7 +773,8 @@ defmodule SymphonyElixir.ExtensionsTest do
     StatusDashboard.notify_update()
 
     assert_eventually(fn ->
-      render(view) =~ "agent message content streaming: structured update"
+      html = render(view)
+      html =~ "agent message content streaming: structured update" and html =~ "Activity (1)"
     end)
   end
 

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -117,6 +117,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
              message: %{method: "some-event"},
              timestamp: now
            }
+
+    assert [
+             %{event: :notification, message: %{method: "some-event"}, timestamp: ^now},
+             %{event: :session_started, message: nil, timestamp: ^now}
+           ] = snapshot_entry.recent_codex_messages
   end
 
   test "orchestrator can stop a running issue session by identifier" do


### PR DESCRIPTION
#### Context

Operators need a way to inspect recent Codex session messages behind terse dashboard status labels.

#### TL;DR

*Add expandable recent activity history to session observability.*

#### Summary

- Store the latest 20 Codex updates on each running session.
- Preserve recent activity when sessions move into past-session history.
- Expose `recent_events` in state and per-issue observability payloads.
- Render expandable Activity panels in running and past session tables.
- Add tests for orchestrator history, API payloads, and LiveView rendering.

#### Alternatives

- A title-only tooltip was considered, but it would still expose only the latest event.
- A separate sidebar can build on the same `recent_events` payload later.

#### Test Plan

- [x] `mix test test/symphony_elixir/orchestrator_status_test.exs test/symphony_elixir/extensions_test.exs`
- [x] `mix compile --warnings-as-errors`
- [ ] `make -C elixir all`